### PR TITLE
Add i18n coverage for admin new/edit forms

### DIFF
--- a/frontend/src/components/admin/prompt-slots/SlotTypeSelector.tsx
+++ b/frontend/src/components/admin/prompt-slots/SlotTypeSelector.tsx
@@ -76,20 +76,14 @@ export function SlotTypeSelector({ selectedSlotIds, onSelectionChange }: SlotTyp
   }
 
   if (sortedSlotTypes.length === 0) {
-    return (
-      <div className="rounded border border-gray-200 bg-gray-50 px-4 py-3 text-gray-600">
-        {t('prompt.slotSelector.empty')}
-      </div>
-    );
+    return <div className="rounded border border-gray-200 bg-gray-50 px-4 py-3 text-gray-600">{t('prompt.slotSelector.empty')}</div>;
   }
 
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <Label>{t('prompt.slotSelector.label')}</Label>
-        <Badge variant="secondary">
-          {t('prompt.slotSelector.badge', { selected: selectedSlotIds.length, total: sortedSlotTypes.length })}
-        </Badge>
+        <Badge variant="secondary">{t('prompt.slotSelector.badge', { selected: selectedSlotIds.length, total: sortedSlotTypes.length })}</Badge>
       </div>
 
       <Accordion type="multiple" className="w-full">

--- a/frontend/src/components/admin/prompt-slots/SlotTypeSelector.tsx
+++ b/frontend/src/components/admin/prompt-slots/SlotTypeSelector.tsx
@@ -3,7 +3,8 @@ import { Badge } from '@/components/ui/Badge';
 import { Label } from '@/components/ui/Label';
 import { promptSlotVariantsApi } from '@/lib/api';
 import type { PromptSlotType, PromptSlotVariant } from '@/types/promptSlotVariant';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface SlotTypeSelectorProps {
   selectedSlotIds: number[];
@@ -11,15 +12,12 @@ interface SlotTypeSelectorProps {
 }
 
 export function SlotTypeSelector({ selectedSlotIds, onSelectionChange }: SlotTypeSelectorProps) {
+  const { t } = useTranslation('admin');
   const [slotVariants, setSlotVariants] = useState<PromptSlotVariant[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    fetchSlotVariants();
-  }, []);
-
-  const fetchSlotVariants = async () => {
+  const fetchSlotVariants = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -27,11 +25,15 @@ export function SlotTypeSelector({ selectedSlotIds, onSelectionChange }: SlotTyp
       setSlotVariants(data);
     } catch (error) {
       console.error('Error fetching slot variants:', error);
-      setError('Failed to load slot variants');
+      setError(t('prompt.slotSelector.errors.load'));
     } finally {
       setLoading(false);
     }
-  };
+  }, [t]);
+
+  useEffect(() => {
+    fetchSlotVariants();
+  }, [fetchSlotVariants]);
 
   // Group slot variants by type
   const slotVariantsByType = slotVariants.reduce(
@@ -40,7 +42,7 @@ export function SlotTypeSelector({ selectedSlotIds, onSelectionChange }: SlotTyp
 
       if (!acc[typeId]) {
         acc[typeId] = {
-          type: slot.promptSlotType || { id: 0, name: 'Other', position: 999 },
+          type: slot.promptSlotType || { id: 0, name: t('prompt.slotSelector.fallbackType'), position: 999 },
           slotVariants: [],
         };
       }
@@ -66,7 +68,7 @@ export function SlotTypeSelector({ selectedSlotIds, onSelectionChange }: SlotTyp
   };
 
   if (loading) {
-    return <div className="py-8 text-center text-gray-500">Loading slot variants...</div>;
+    return <div className="py-8 text-center text-gray-500">{t('prompt.slotSelector.loading')}</div>;
   }
 
   if (error) {
@@ -76,7 +78,7 @@ export function SlotTypeSelector({ selectedSlotIds, onSelectionChange }: SlotTyp
   if (sortedSlotTypes.length === 0) {
     return (
       <div className="rounded border border-gray-200 bg-gray-50 px-4 py-3 text-gray-600">
-        No slot variants available. Please create slot variants first.
+        {t('prompt.slotSelector.empty')}
       </div>
     );
   }
@@ -84,9 +86,9 @@ export function SlotTypeSelector({ selectedSlotIds, onSelectionChange }: SlotTyp
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <Label>Prompt Slot Variants</Label>
+        <Label>{t('prompt.slotSelector.label')}</Label>
         <Badge variant="secondary">
-          {selectedSlotIds.length} of {sortedSlotTypes.length} types selected
+          {t('prompt.slotSelector.badge', { selected: selectedSlotIds.length, total: sortedSlotTypes.length })}
         </Badge>
       </div>
 
@@ -101,7 +103,7 @@ export function SlotTypeSelector({ selectedSlotIds, onSelectionChange }: SlotTyp
                   <span>{type.name}</span>
                   {isSelected && (
                     <Badge variant="default" className="h-5 text-xs">
-                      Selected
+                      {t('prompt.slotSelector.selectedBadge')}
                     </Badge>
                   )}
                 </div>
@@ -121,7 +123,11 @@ export function SlotTypeSelector({ selectedSlotIds, onSelectionChange }: SlotTyp
                         <div className="text-sm text-gray-600">{slot.prompt}</div>
                         {slot.description && <div className="text-sm text-gray-500">{slot.description}</div>}
                         {slot.exampleImageUrl && (
-                          <img src={slot.exampleImageUrl} alt={`Example for ${slot.name}`} className="mt-2 h-20 w-20 rounded object-cover" />
+                          <img
+                            src={slot.exampleImageUrl}
+                            alt={t('prompt.slotSelector.exampleAlt', { name: slot.name })}
+                            className="mt-2 h-20 w-20 rounded object-cover"
+                          />
                         )}
                       </div>
                     </label>

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,20 +1,58 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
+import deAdminCommon from './locales/de/admin/common.json';
+import deAdminArticleCategory from './locales/de/admin/newOrEditArticleCategory.json';
+import deAdminArticleSubCategory from './locales/de/admin/newOrEditArticleSubCategory.json';
+import deAdminPrompt from './locales/de/admin/newOrEditPrompt.json';
+import deAdminPromptSlotType from './locales/de/admin/newOrEditPromptSlotType.json';
+import deAdminPromptSlotVariant from './locales/de/admin/newOrEditPromptSlotVariant.json';
+import deAdminSupplier from './locales/de/admin/newOrEditSupplier.json';
+import deAdminVat from './locales/de/admin/newOrEditVat.json';
 import deCart from './locales/de/cart.json';
 import deCheckout from './locales/de/checkout.json';
 import deEditor from './locales/de/editor.json';
 import deVat from './locales/de/vat.json';
+import enAdminCommon from './locales/en/admin/common.json';
+import enAdminArticleCategory from './locales/en/admin/newOrEditArticleCategory.json';
+import enAdminArticleSubCategory from './locales/en/admin/newOrEditArticleSubCategory.json';
+import enAdminPrompt from './locales/en/admin/newOrEditPrompt.json';
+import enAdminPromptSlotType from './locales/en/admin/newOrEditPromptSlotType.json';
+import enAdminPromptSlotVariant from './locales/en/admin/newOrEditPromptSlotVariant.json';
+import enAdminSupplier from './locales/en/admin/newOrEditSupplier.json';
+import enAdminVat from './locales/en/admin/newOrEditVat.json';
 import enCart from './locales/en/cart.json';
 import enCheckout from './locales/en/checkout.json';
 import enEditor from './locales/en/editor.json';
 import enVat from './locales/en/vat.json';
 
+const deAdmin = {
+  common: deAdminCommon,
+  articleCategory: deAdminArticleCategory,
+  articleSubCategory: deAdminArticleSubCategory,
+  prompt: deAdminPrompt,
+  promptSlotType: deAdminPromptSlotType,
+  promptSlotVariant: deAdminPromptSlotVariant,
+  supplier: deAdminSupplier,
+  vatForm: deAdminVat,
+} as const;
+
+const enAdmin = {
+  common: enAdminCommon,
+  articleCategory: enAdminArticleCategory,
+  articleSubCategory: enAdminArticleSubCategory,
+  prompt: enAdminPrompt,
+  promptSlotType: enAdminPromptSlotType,
+  promptSlotVariant: enAdminPromptSlotVariant,
+  supplier: enAdminSupplier,
+  vatForm: enAdminVat,
+} as const;
+
 export const defaultNS = 'vat';
 export const LANGUAGE_STORAGE_KEY = 'voenix.shop.language';
 export const resources = {
-  en: { vat: enVat, cart: enCart, checkout: enCheckout, editor: enEditor },
-  de: { vat: deVat, cart: deCart, checkout: deCheckout, editor: deEditor },
+  en: { vat: enVat, cart: enCart, checkout: enCheckout, editor: enEditor, admin: enAdmin },
+  de: { vat: deVat, cart: deCart, checkout: deCheckout, editor: deEditor, admin: deAdmin },
 } as const;
 export const namespaces = Object.freeze(Object.keys(resources.en)) as readonly (keyof typeof resources.en)[];
 

--- a/frontend/src/locales/de/admin/common.json
+++ b/frontend/src/locales/de/admin/common.json
@@ -1,0 +1,18 @@
+{
+  "loading": "Wird geladen...",
+  "actions": {
+    "cancel": "Abbrechen",
+    "uploadImage": "Bild hochladen"
+  },
+  "status": {
+    "saving": "Speichern...",
+    "uploadingImage": "Bild wird hochgeladen..."
+  },
+  "placeholders": {
+    "select": "Auswählen",
+    "unit": "1,00"
+  },
+  "errors": {
+    "generic": "Ein Fehler ist aufgetreten"
+  }
+}

--- a/frontend/src/locales/de/admin/newOrEditArticleCategory.json
+++ b/frontend/src/locales/de/admin/newOrEditArticleCategory.json
@@ -1,0 +1,27 @@
+{
+  "title": {
+    "new": "Neue Artikelkategorie",
+    "edit": "Artikelkategorie bearbeiten"
+  },
+  "description": {
+    "new": "Erstellen Sie mit dem Formular unten eine neue Artikelkategorie",
+    "edit": "Aktualisieren Sie die Details der Artikelkategorie unten"
+  },
+  "form": {
+    "name": "Name *",
+    "namePlaceholder": "Name der Artikelkategorie eingeben",
+    "description": "Beschreibung",
+    "descriptionPlaceholder": "Beschreibung der Artikelkategorie eingeben (optional)",
+    "charCount": "{{count}}/{{max}} Zeichen"
+  },
+  "errors": {
+    "load": "Artikelkategorie konnte nicht geladen werden",
+    "save": "Artikelkategorie konnte nicht gespeichert werden. Bitte erneut versuchen.",
+    "nameRequired": "Name ist erforderlich",
+    "nameMaxLength": "Name darf maximal 255 Zeichen enthalten"
+  },
+  "actions": {
+    "create": "Kategorie erstellen",
+    "update": "Kategorie aktualisieren"
+  }
+}

--- a/frontend/src/locales/de/admin/newOrEditArticleSubCategory.json
+++ b/frontend/src/locales/de/admin/newOrEditArticleSubCategory.json
@@ -1,0 +1,32 @@
+{
+  "title": {
+    "new": "Neue Artikelsubkategorie",
+    "edit": "Artikelsubkategorie bearbeiten"
+  },
+  "description": {
+    "new": "Erstellen Sie mit dem Formular unten eine neue Artikelsubkategorie",
+    "edit": "Aktualisieren Sie die Details der Artikelsubkategorie unten"
+  },
+  "form": {
+    "category": "Kategorie",
+    "categoryPlaceholder": "Kategorie auswählen",
+    "name": "Name",
+    "namePlaceholder": "Name der Subkategorie eingeben",
+    "description": "Beschreibung",
+    "descriptionPlaceholder": "Beschreibung der Subkategorie eingeben (optional)",
+    "subcategory": "Subkategorie (optional)",
+    "subcategoryPlaceholder": "Subkategorie auswählen (optional)",
+    "noSubcategory": "Keine Subkategorie"
+  },
+  "errors": {
+    "loadCategories": "Artikelkategorien konnten nicht geladen werden",
+    "load": "Artikelsubkategorie konnte nicht geladen werden",
+    "save": "Artikelsubkategorie konnte nicht gespeichert werden. Bitte erneut versuchen.",
+    "nameRequired": "Name ist erforderlich",
+    "categoryRequired": "Kategorie ist erforderlich"
+  },
+  "actions": {
+    "create": "Subkategorie erstellen",
+    "update": "Subkategorie aktualisieren"
+  }
+}

--- a/frontend/src/locales/de/admin/newOrEditPrompt.json
+++ b/frontend/src/locales/de/admin/newOrEditPrompt.json
@@ -1,0 +1,109 @@
+{
+  "tabs": {
+    "prompt": "Prompt",
+    "costCalculation": "Preisberechnung"
+  },
+  "title": {
+    "new": "Neuer Prompt",
+    "edit": "Prompt bearbeiten"
+  },
+  "description": {
+    "new": "Erstellen Sie mit dem Formular unten einen neuen Prompt",
+    "edit": "Aktualisieren Sie die Prompt-Details unten"
+  },
+  "form": {
+    "title": "Titel",
+    "titlePlaceholder": "Prompt-Titel eingeben",
+    "promptNumber": "Prompt-Nummer",
+    "category": "Kategorie",
+    "categoryPlaceholder": "Kategorie auswählen",
+    "subcategory": "Subkategorie (optional)",
+    "subcategoryPlaceholder": "Subkategorie auswählen (optional)",
+    "noSubcategory": "Keine Subkategorie",
+    "promptStyle": "Prompt-Stil (optional)",
+    "promptStylePlaceholder": "Prompt-Text eingeben...",
+    "status": "Status",
+    "statusHint": "Diesen Prompt zur Nutzung freigeben"
+  },
+  "exampleImage": {
+    "label": "Beispielbild (optional)",
+    "hint": "PNG, JPG, GIF oder WEBP (wird automatisch in WebP umgewandelt)",
+    "alt": "Prompt-Beispiel"
+  },
+  "errors": {
+    "loadCategories": "Kategorien konnten nicht geladen werden",
+    "loadSubcategories": "Unterkategorien konnten nicht geladen werden",
+    "load": "Prompt konnte nicht geladen werden",
+    "save": "Prompt konnte nicht gespeichert werden. Bitte erneut versuchen.",
+    "titleRequired": "Titel ist erforderlich",
+    "categoryRequired": "Kategorie ist erforderlich",
+    "invalidImage": "Bitte wählen Sie eine gültige Bilddatei aus",
+    "imageTooLarge": "Dateigröße überschreitet das maximale Limit von 10 MB",
+    "uploadImage": "Bild konnte nicht hochgeladen werden: {{message}}"
+  },
+  "actions": {
+    "create": "Prompt erstellen",
+    "update": "Prompt aktualisieren"
+  },
+  "slotSelector": {
+    "label": "Prompt-Slot-Varianten",
+    "loading": "Slot-Varianten werden geladen...",
+    "errors": {
+      "load": "Slot-Varianten konnten nicht geladen werden"
+    },
+    "empty": "Keine Slot-Varianten vorhanden. Bitte erstellen Sie zuerst Slot-Varianten.",
+    "badge": "{{selected}} von {{total}} Typen ausgewählt",
+    "selectedBadge": "Ausgewählt",
+    "fallbackType": "Andere",
+    "exampleAlt": "Beispiel für {{name}}"
+  },
+  "priceCalculation": {
+    "purchase": {
+      "title": "Einkauf",
+      "description": "Einkaufspreis und Preisberechnungen",
+      "taxRateLabel": "Steuersatz",
+      "taxRatePlaceholder": "Umsatzsteuersatz auswählen",
+      "taxRateHint": "(aus Artikel- oder Dienstleistungsgruppe)",
+      "mode": {
+        "net": "Netto",
+        "gross": "Brutto"
+      },
+      "headers": {
+        "net": "Netto",
+        "tax": "Steuer",
+        "gross": "Brutto"
+      },
+      "priceLabel": "Einkaufspreis",
+      "costLabel": "Einkaufskosten",
+      "costPercentLabel": "Einkaufskosten %",
+      "totalLabel": "Einkauf gesamt",
+      "priceCorrespondsLabel": "Preis entspricht",
+      "priceCorrespondsPlaceholder": "Auswählen",
+      "unitPlaceholder": "1,00",
+      "unitHint": "Mengeneinheit(en) oder Verpackung"
+    },
+    "sales": {
+      "title": "Verkauf",
+      "description": "Verkaufspreis- und Margenberechnungen",
+      "taxRateLabel": "Steuersatz",
+      "taxRatePlaceholder": "Umsatzsteuersatz auswählen",
+      "taxRateHint": "(aus Artikel- oder Dienstleistungsgruppe)",
+      "mode": {
+        "net": "Netto",
+        "gross": "Brutto"
+      },
+      "headers": {
+        "net": "Netto",
+        "tax": "Steuer",
+        "gross": "Brutto"
+      },
+      "marginLabel": "Marge",
+      "marginPercentLabel": "Marge %",
+      "totalLabel": "Verkauf gesamt",
+      "priceCorrespondsLabel": "Preis entspricht",
+      "priceCorrespondsPlaceholder": "Auswählen",
+      "unitPlaceholder": "1,00",
+      "unitHint": "Mengeneinheit(en) oder Verpackung"
+    }
+  }
+}

--- a/frontend/src/locales/de/admin/newOrEditPromptSlotType.json
+++ b/frontend/src/locales/de/admin/newOrEditPromptSlotType.json
@@ -1,0 +1,23 @@
+{
+  "title": {
+    "new": "Neuer Slot-Typ",
+    "edit": "Slot-Typ bearbeiten"
+  },
+  "description": {
+    "new": "Erstellen Sie mit dem Formular unten einen neuen Slot-Typ",
+    "edit": "Aktualisieren Sie die Slot-Typ-Details unten"
+  },
+  "form": {
+    "name": "Name",
+    "namePlaceholder": "Name des Slot-Typs eingeben"
+  },
+  "errors": {
+    "load": "Slot-Typ konnte nicht geladen werden",
+    "save": "Slot-Typ konnte nicht gespeichert werden. Bitte erneut versuchen.",
+    "nameRequired": "Name ist erforderlich"
+  },
+  "actions": {
+    "create": "Slot-Typ erstellen",
+    "update": "Slot-Typ aktualisieren"
+  }
+}

--- a/frontend/src/locales/de/admin/newOrEditPromptSlotVariant.json
+++ b/frontend/src/locales/de/admin/newOrEditPromptSlotVariant.json
@@ -1,0 +1,38 @@
+{
+  "title": {
+    "new": "Neuer Slot",
+    "edit": "Slot bearbeiten"
+  },
+  "description": {
+    "new": "Erstellen Sie mit dem Formular unten einen neuen Slot",
+    "edit": "Aktualisieren Sie die Slot-Details unten"
+  },
+  "form": {
+    "name": "Name",
+    "namePlaceholder": "Slot-Namen eingeben",
+    "type": "Prompt-Slot-Typ",
+    "typePlaceholder": "Prompt-Slot-Typ auswählen",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Prompt-Text eingeben",
+    "description": "Beschreibung",
+    "descriptionPlaceholder": "Optionale Beschreibung für diesen Slot eingeben",
+    "exampleImage": "Beispielbild",
+    "exampleHint": "Optionales Beispielbild für diesen Slot",
+    "exampleAlt": "Beispielbild"
+  },
+  "errors": {
+    "loadTypes": "Prompt-Slot-Typen konnten nicht geladen werden",
+    "load": "Slot konnte nicht geladen werden",
+    "save": "Slot konnte nicht gespeichert werden. Bitte erneut versuchen.",
+    "nameRequired": "Name ist erforderlich",
+    "typeRequired": "Prompt-Slot-Typ ist erforderlich",
+    "promptRequired": "Prompt ist erforderlich",
+    "invalidImage": "Bitte laden Sie eine Bilddatei hoch",
+    "imageTooLarge": "Bildgröße muss kleiner als 5 MB sein",
+    "uploadImage": "Bild konnte nicht hochgeladen werden. Bitte erneut versuchen."
+  },
+  "actions": {
+    "create": "Slot erstellen",
+    "update": "Slot aktualisieren"
+  }
+}

--- a/frontend/src/locales/de/admin/newOrEditSupplier.json
+++ b/frontend/src/locales/de/admin/newOrEditSupplier.json
@@ -1,0 +1,65 @@
+{
+  "breadcrumb": {
+    "back": "Zurück zu den Lieferanten"
+  },
+  "title": {
+    "new": "Neuen Lieferanten anlegen",
+    "edit": "Lieferanten bearbeiten"
+  },
+  "sections": {
+    "company": {
+      "title": "Unternehmensinformationen",
+      "description": "Grundlegende Informationen zum Lieferanten"
+    },
+    "contact": {
+      "title": "Ansprechpartner",
+      "description": "Hauptansprechpartner beim Lieferanten"
+    },
+    "address": {
+      "title": "Adresse",
+      "description": "Physische Adresse des Lieferanten"
+    },
+    "phone": {
+      "title": "Telefonnummern",
+      "description": "Kontakttelefonnummern des Lieferanten"
+    }
+  },
+  "form": {
+    "name": "Firmenname",
+    "namePlaceholder": "z. B. ABC Supplies GmbH",
+    "website": "Webseite",
+    "websitePlaceholder": "z. B. https://www.beispiel.de",
+    "title": "Anrede",
+    "titlePlaceholder": "z. B. Herr, Frau, Dr.",
+    "firstName": "Vorname",
+    "firstNamePlaceholder": "z. B. Max",
+    "lastName": "Nachname",
+    "lastNamePlaceholder": "z. B. Mustermann",
+    "email": "E-Mail",
+    "emailPlaceholder": "z. B. kontakt@beispiel.de",
+    "street": "Straße",
+    "streetPlaceholder": "z. B. Hauptstraße",
+    "houseNumber": "Hausnummer",
+    "houseNumberPlaceholder": "z. B. 123",
+    "city": "Stadt",
+    "cityPlaceholder": "z. B. Berlin",
+    "postalCode": "Postleitzahl",
+    "postalCodePlaceholder": "z. B. 10115",
+    "country": "Land",
+    "countryPlaceholder": "Land auswählen",
+    "phoneNumber1": "Telefon (primär)",
+    "phoneNumber1Placeholder": "z. B. +49 30 12345678",
+    "phoneNumber2": "Telefon (sekundär)",
+    "phoneNumber2Placeholder": "z. B. +49 30 87654321",
+    "phoneNumber3": "Mobiltelefon",
+    "phoneNumber3Placeholder": "z. B. +49 170 1234567"
+  },
+  "errors": {
+    "invalidEmail": "Ungültiges E-Mail-Format",
+    "postalCode": "Postleitzahl muss eine positive Zahl sein"
+  },
+  "actions": {
+    "create": "Lieferanten erstellen",
+    "update": "Lieferanten aktualisieren"
+  }
+}

--- a/frontend/src/locales/de/admin/newOrEditVat.json
+++ b/frontend/src/locales/de/admin/newOrEditVat.json
@@ -1,0 +1,36 @@
+{
+  "breadcrumb": {
+    "back": "Zurück zur Umsatzsteuerliste"
+  },
+  "title": {
+    "new": "Neue Umsatzsteuer anlegen",
+    "edit": "Umsatzsteuer bearbeiten"
+  },
+  "cardTitle": {
+    "new": "Umsatzsteuer-Details",
+    "edit": "Umsatzsteuerdetails bearbeiten"
+  },
+  "cardDescription": {
+    "new": "Geben Sie die Details für den neuen Umsatzsteuersatz ein.",
+    "edit": "Aktualisieren Sie die Umsatzsteuerinformationen unten."
+  },
+  "form": {
+    "name": "Name *",
+    "namePlaceholder": "z. B. Standard-USt",
+    "percent": "Prozent (%) *",
+    "percentPlaceholder": "z. B. 19",
+    "description": "Beschreibung",
+    "descriptionPlaceholder": "Optionale Beschreibung für diesen Umsatzsteuersatz",
+    "isDefault": "Als Standard-Umsatzsteuer festlegen"
+  },
+  "errors": {
+    "nameRequired": "Name ist erforderlich",
+    "percentRequired": "Prozentsatz ist erforderlich",
+    "percentPositive": "Prozentsatz muss eine positive Zahl sein"
+  },
+  "loading": "Umsatzsteuerdaten werden geladen...",
+  "actions": {
+    "create": "Umsatzsteuer erstellen",
+    "update": "Umsatzsteuer aktualisieren"
+  }
+}

--- a/frontend/src/locales/en/admin/common.json
+++ b/frontend/src/locales/en/admin/common.json
@@ -1,0 +1,18 @@
+{
+  "loading": "Loading...",
+  "actions": {
+    "cancel": "Cancel",
+    "uploadImage": "Upload Image"
+  },
+  "status": {
+    "saving": "Saving...",
+    "uploadingImage": "Uploading image..."
+  },
+  "placeholders": {
+    "select": "Select",
+    "unit": "1.00"
+  },
+  "errors": {
+    "generic": "An error occurred"
+  }
+}

--- a/frontend/src/locales/en/admin/newOrEditArticleCategory.json
+++ b/frontend/src/locales/en/admin/newOrEditArticleCategory.json
@@ -1,0 +1,27 @@
+{
+  "title": {
+    "new": "New Article Category",
+    "edit": "Edit Article Category"
+  },
+  "description": {
+    "new": "Create a new article category with the form below",
+    "edit": "Update the article category details below"
+  },
+  "form": {
+    "name": "Name *",
+    "namePlaceholder": "Enter article category name",
+    "description": "Description",
+    "descriptionPlaceholder": "Enter article category description (optional)",
+    "charCount": "{{count}}/{{max}} characters"
+  },
+  "errors": {
+    "load": "Failed to load article category",
+    "save": "Failed to save article category. Please try again.",
+    "nameRequired": "Name is required",
+    "nameMaxLength": "Name must not exceed 255 characters"
+  },
+  "actions": {
+    "create": "Create Category",
+    "update": "Update Category"
+  }
+}

--- a/frontend/src/locales/en/admin/newOrEditArticleSubCategory.json
+++ b/frontend/src/locales/en/admin/newOrEditArticleSubCategory.json
@@ -1,0 +1,32 @@
+{
+  "title": {
+    "new": "New Article Subcategory",
+    "edit": "Edit Article Subcategory"
+  },
+  "description": {
+    "new": "Create a new article subcategory with the form below",
+    "edit": "Update the article subcategory details below"
+  },
+  "form": {
+    "category": "Category",
+    "categoryPlaceholder": "Select a category",
+    "name": "Name",
+    "namePlaceholder": "Enter subcategory name",
+    "description": "Description",
+    "descriptionPlaceholder": "Enter subcategory description (optional)",
+    "subcategory": "Subcategory (optional)",
+    "subcategoryPlaceholder": "Select a subcategory (optional)",
+    "noSubcategory": "No subcategory"
+  },
+  "errors": {
+    "loadCategories": "Failed to load article categories",
+    "load": "Failed to load article subcategory",
+    "save": "Failed to save article subcategory. Please try again.",
+    "nameRequired": "Name is required",
+    "categoryRequired": "Category is required"
+  },
+  "actions": {
+    "create": "Create Subcategory",
+    "update": "Update Subcategory"
+  }
+}

--- a/frontend/src/locales/en/admin/newOrEditPrompt.json
+++ b/frontend/src/locales/en/admin/newOrEditPrompt.json
@@ -1,0 +1,109 @@
+{
+  "tabs": {
+    "prompt": "Prompt",
+    "costCalculation": "Price Calculation"
+  },
+  "title": {
+    "new": "New Prompt",
+    "edit": "Edit Prompt"
+  },
+  "description": {
+    "new": "Create a new prompt with the form below",
+    "edit": "Update the prompt details below"
+  },
+  "form": {
+    "title": "Title",
+    "titlePlaceholder": "Enter prompt title",
+    "promptNumber": "Prompt Number",
+    "category": "Category",
+    "categoryPlaceholder": "Select a category",
+    "subcategory": "Subcategory (optional)",
+    "subcategoryPlaceholder": "Select a subcategory (optional)",
+    "noSubcategory": "No subcategory",
+    "promptStyle": "Prompt Style (optional)",
+    "promptStylePlaceholder": "Enter the prompt text content...",
+    "status": "Status",
+    "statusHint": "Make this prompt available for use"
+  },
+  "exampleImage": {
+    "label": "Example Image (optional)",
+    "hint": "PNG, JPG, GIF, or WEBP (automatically converted to WebP)",
+    "alt": "Prompt example"
+  },
+  "errors": {
+    "loadCategories": "Failed to load categories",
+    "loadSubcategories": "Failed to load subcategories",
+    "load": "Failed to load prompt",
+    "save": "Failed to save prompt. Please try again.",
+    "titleRequired": "Title is required",
+    "categoryRequired": "Category is required",
+    "invalidImage": "Please select a valid image file",
+    "imageTooLarge": "File size exceeds maximum allowed size of 10MB",
+    "uploadImage": "Failed to upload image: {{message}}"
+  },
+  "actions": {
+    "create": "Create Prompt",
+    "update": "Update Prompt"
+  },
+  "slotSelector": {
+    "label": "Prompt Slot Variants",
+    "loading": "Loading slot variants...",
+    "errors": {
+      "load": "Failed to load slot variants"
+    },
+    "empty": "No slot variants available. Please create slot variants first.",
+    "badge": "{{selected}} of {{total}} types selected",
+    "selectedBadge": "Selected",
+    "fallbackType": "Other",
+    "exampleAlt": "Example for {{name}}"
+  },
+  "priceCalculation": {
+    "purchase": {
+      "title": "Purchase",
+      "description": "Purchase price and price calculations",
+      "taxRateLabel": "Tax Rate",
+      "taxRatePlaceholder": "Select VAT rate",
+      "taxRateHint": "(from article or service group)",
+      "mode": {
+        "net": "Net",
+        "gross": "Gross"
+      },
+      "headers": {
+        "net": "Net",
+        "tax": "Tax",
+        "gross": "Gross"
+      },
+      "priceLabel": "Purchase Price",
+      "costLabel": "Purchase Cost",
+      "costPercentLabel": "Purchase Cost %",
+      "totalLabel": "Purchase Total",
+      "priceCorrespondsLabel": "Price corresponds to",
+      "priceCorrespondsPlaceholder": "Select",
+      "unitPlaceholder": "1.00",
+      "unitHint": "Quantity unit(s) or packaging"
+    },
+    "sales": {
+      "title": "Sales",
+      "description": "Sales price and margin calculations",
+      "taxRateLabel": "Tax Rate",
+      "taxRatePlaceholder": "Select VAT rate",
+      "taxRateHint": "(from article or service group)",
+      "mode": {
+        "net": "Net",
+        "gross": "Gross"
+      },
+      "headers": {
+        "net": "Net",
+        "tax": "Tax",
+        "gross": "Gross"
+      },
+      "marginLabel": "Margin",
+      "marginPercentLabel": "Margin %",
+      "totalLabel": "Sales Total",
+      "priceCorrespondsLabel": "Price corresponds to",
+      "priceCorrespondsPlaceholder": "Select",
+      "unitPlaceholder": "1.00",
+      "unitHint": "Quantity unit(s) or packaging"
+    }
+  }
+}

--- a/frontend/src/locales/en/admin/newOrEditPromptSlotType.json
+++ b/frontend/src/locales/en/admin/newOrEditPromptSlotType.json
@@ -1,0 +1,23 @@
+{
+  "title": {
+    "new": "New Slot Type",
+    "edit": "Edit Slot Type"
+  },
+  "description": {
+    "new": "Create a new slot type with the form below",
+    "edit": "Update the slot type details below"
+  },
+  "form": {
+    "name": "Name",
+    "namePlaceholder": "Enter slot type name"
+  },
+  "errors": {
+    "load": "Failed to load prompt slot type",
+    "save": "Failed to save prompt slot type. Please try again.",
+    "nameRequired": "Name is required"
+  },
+  "actions": {
+    "create": "Create Slot Type",
+    "update": "Update Slot Type"
+  }
+}

--- a/frontend/src/locales/en/admin/newOrEditPromptSlotVariant.json
+++ b/frontend/src/locales/en/admin/newOrEditPromptSlotVariant.json
@@ -1,0 +1,38 @@
+{
+  "title": {
+    "new": "New Slot",
+    "edit": "Edit Slot"
+  },
+  "description": {
+    "new": "Create a new slot with the form below",
+    "edit": "Update the slot details below"
+  },
+  "form": {
+    "name": "Name",
+    "namePlaceholder": "Enter slot name",
+    "type": "Prompt Slot Type",
+    "typePlaceholder": "Select a prompt slot type",
+    "prompt": "Prompt",
+    "promptPlaceholder": "Enter the prompt text",
+    "description": "Description",
+    "descriptionPlaceholder": "Enter an optional description for this slot",
+    "exampleImage": "Example Image",
+    "exampleHint": "Optional example image for this slot",
+    "exampleAlt": "Example image"
+  },
+  "errors": {
+    "loadTypes": "Failed to load prompt slot types",
+    "load": "Failed to load slot",
+    "save": "Failed to save slot. Please try again.",
+    "nameRequired": "Name is required",
+    "typeRequired": "Prompt slot type is required",
+    "promptRequired": "Prompt is required",
+    "invalidImage": "Please upload an image file",
+    "imageTooLarge": "Image size must be less than 5MB",
+    "uploadImage": "Failed to upload image. Please try again."
+  },
+  "actions": {
+    "create": "Create Slot",
+    "update": "Update Slot"
+  }
+}

--- a/frontend/src/locales/en/admin/newOrEditSupplier.json
+++ b/frontend/src/locales/en/admin/newOrEditSupplier.json
@@ -1,0 +1,65 @@
+{
+  "breadcrumb": {
+    "back": "Back to Suppliers"
+  },
+  "title": {
+    "new": "Create New Supplier",
+    "edit": "Edit Supplier"
+  },
+  "sections": {
+    "company": {
+      "title": "Company Information",
+      "description": "Basic information about the supplier company"
+    },
+    "contact": {
+      "title": "Contact Person",
+      "description": "Primary contact person at the supplier"
+    },
+    "address": {
+      "title": "Address",
+      "description": "Physical address of the supplier"
+    },
+    "phone": {
+      "title": "Phone Numbers",
+      "description": "Contact phone numbers for the supplier"
+    }
+  },
+  "form": {
+    "name": "Company Name",
+    "namePlaceholder": "e.g., ABC Supplies Ltd.",
+    "website": "Website",
+    "websitePlaceholder": "e.g., https://www.example.com",
+    "title": "Title",
+    "titlePlaceholder": "e.g., Mr., Ms., Dr.",
+    "firstName": "First Name",
+    "firstNamePlaceholder": "e.g., John",
+    "lastName": "Last Name",
+    "lastNamePlaceholder": "e.g., Doe",
+    "email": "Email",
+    "emailPlaceholder": "e.g., contact@example.com",
+    "street": "Street",
+    "streetPlaceholder": "e.g., Main Street",
+    "houseNumber": "House Number",
+    "houseNumberPlaceholder": "e.g., 123",
+    "city": "City",
+    "cityPlaceholder": "e.g., Berlin",
+    "postalCode": "Postal Code",
+    "postalCodePlaceholder": "e.g., 10115",
+    "country": "Country",
+    "countryPlaceholder": "Select a country",
+    "phoneNumber1": "Primary Phone",
+    "phoneNumber1Placeholder": "e.g., +49 30 12345678",
+    "phoneNumber2": "Secondary Phone",
+    "phoneNumber2Placeholder": "e.g., +49 30 87654321",
+    "phoneNumber3": "Mobile Phone",
+    "phoneNumber3Placeholder": "e.g., +49 170 1234567"
+  },
+  "errors": {
+    "invalidEmail": "Invalid email format",
+    "postalCode": "Postal code must be a positive number"
+  },
+  "actions": {
+    "create": "Create Supplier",
+    "update": "Update Supplier"
+  }
+}

--- a/frontend/src/locales/en/admin/newOrEditVat.json
+++ b/frontend/src/locales/en/admin/newOrEditVat.json
@@ -1,0 +1,36 @@
+{
+  "breadcrumb": {
+    "back": "Back to VAT List"
+  },
+  "title": {
+    "new": "Create New VAT",
+    "edit": "Edit VAT"
+  },
+  "cardTitle": {
+    "new": "VAT Details",
+    "edit": "Edit VAT Details"
+  },
+  "cardDescription": {
+    "new": "Enter the details for the new VAT entry.",
+    "edit": "Update the VAT information below."
+  },
+  "form": {
+    "name": "Name *",
+    "namePlaceholder": "e.g., Standard VAT",
+    "percent": "Percent (%) *",
+    "percentPlaceholder": "e.g., 19",
+    "description": "Description",
+    "descriptionPlaceholder": "Optional description for this VAT rate",
+    "isDefault": "Set as default VAT"
+  },
+  "errors": {
+    "nameRequired": "Name is required",
+    "percentRequired": "Percent is required",
+    "percentPositive": "Percent must be a positive number"
+  },
+  "loading": "Loading VAT data...",
+  "actions": {
+    "create": "Create VAT",
+    "update": "Update VAT"
+  }
+}

--- a/frontend/src/pages/admin/NewOrEditArticleCategory.tsx
+++ b/frontend/src/pages/admin/NewOrEditArticleCategory.tsx
@@ -6,12 +6,14 @@ import { Textarea } from '@/components/ui/Textarea';
 import type { CreateArticleCategoryRequest, UpdateArticleCategoryRequest } from '@/lib/api';
 import { articleCategoriesApi } from '@/lib/api';
 import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export default function NewOrEditArticleCategory() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const isEditing = !!id;
+  const { t } = useTranslation('admin');
 
   const [formData, setFormData] = useState<CreateArticleCategoryRequest>({
     name: '',
@@ -33,11 +35,11 @@ export default function NewOrEditArticleCategory() {
       });
     } catch (error) {
       console.error('Error fetching article category:', error);
-      setError('Failed to load article category');
+      setError(t('articleCategory.errors.load'));
     } finally {
       setInitialLoading(false);
     }
-  }, [id]);
+  }, [id, t]);
 
   useEffect(() => {
     if (isEditing) {
@@ -51,12 +53,12 @@ export default function NewOrEditArticleCategory() {
     e.preventDefault();
 
     if (!formData.name.trim()) {
-      setError('Name is required');
+      setError(t('articleCategory.errors.nameRequired'));
       return;
     }
 
     if (formData.name.length > 255) {
-      setError('Name must not exceed 255 characters');
+      setError(t('articleCategory.errors.nameMaxLength'));
       return;
     }
 
@@ -81,7 +83,7 @@ export default function NewOrEditArticleCategory() {
       navigate('/admin/article-categories');
     } catch (error) {
       console.error('Error saving article category:', error);
-      setError('Failed to save article category. Please try again.');
+      setError(t('articleCategory.errors.save'));
     } finally {
       setLoading(false);
     }
@@ -95,7 +97,7 @@ export default function NewOrEditArticleCategory() {
     return (
       <div className="container mx-auto p-6">
         <div className="flex h-64 items-center justify-center">
-          <p className="text-gray-500">Loading...</p>
+          <p className="text-gray-500">{t('common.loading')}</p>
         </div>
       </div>
     );
@@ -105,9 +107,9 @@ export default function NewOrEditArticleCategory() {
     <div className="container mx-auto p-6">
       <Card className="mx-auto max-w-2xl">
         <CardHeader>
-          <CardTitle>{isEditing ? 'Edit Article Category' : 'New Article Category'}</CardTitle>
+          <CardTitle>{isEditing ? t('articleCategory.title.edit') : t('articleCategory.title.new')}</CardTitle>
           <CardDescription>
-            {isEditing ? 'Update the article category details below' : 'Create a new article category with the form below'}
+            {isEditing ? t('articleCategory.description.edit') : t('articleCategory.description.new')}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -115,35 +117,41 @@ export default function NewOrEditArticleCategory() {
             {error && <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700">{error}</div>}
 
             <div className="space-y-2">
-              <Label htmlFor="name">Name *</Label>
+              <Label htmlFor="name">{t('articleCategory.form.name')}</Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                placeholder="Enter article category name"
+                placeholder={t('articleCategory.form.namePlaceholder')}
                 maxLength={255}
                 required
               />
-              <p className="text-sm text-gray-500">{formData.name.length}/255 characters</p>
+              <p className="text-sm text-gray-500">
+                {t('articleCategory.form.charCount', { count: formData.name.length, max: 255 })}
+              </p>
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="description">Description</Label>
+              <Label htmlFor="description">{t('articleCategory.form.description')}</Label>
               <Textarea
                 id="description"
                 value={formData.description || ''}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                placeholder="Enter article category description (optional)"
+                placeholder={t('articleCategory.form.descriptionPlaceholder')}
                 rows={4}
               />
             </div>
 
             <div className="flex gap-4">
               <Button type="submit" disabled={loading}>
-                {loading ? 'Saving...' : isEditing ? 'Update Category' : 'Create Category'}
+                {loading
+                  ? t('common.status.saving')
+                  : isEditing
+                    ? t('articleCategory.actions.update')
+                    : t('articleCategory.actions.create')}
               </Button>
               <Button type="button" variant="outline" onClick={handleCancel}>
-                Cancel
+                {t('common.actions.cancel')}
               </Button>
             </div>
           </form>

--- a/frontend/src/pages/admin/NewOrEditArticleCategory.tsx
+++ b/frontend/src/pages/admin/NewOrEditArticleCategory.tsx
@@ -108,9 +108,7 @@ export default function NewOrEditArticleCategory() {
       <Card className="mx-auto max-w-2xl">
         <CardHeader>
           <CardTitle>{isEditing ? t('articleCategory.title.edit') : t('articleCategory.title.new')}</CardTitle>
-          <CardDescription>
-            {isEditing ? t('articleCategory.description.edit') : t('articleCategory.description.new')}
-          </CardDescription>
+          <CardDescription>{isEditing ? t('articleCategory.description.edit') : t('articleCategory.description.new')}</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
@@ -126,9 +124,7 @@ export default function NewOrEditArticleCategory() {
                 maxLength={255}
                 required
               />
-              <p className="text-sm text-gray-500">
-                {t('articleCategory.form.charCount', { count: formData.name.length, max: 255 })}
-              </p>
+              <p className="text-sm text-gray-500">{t('articleCategory.form.charCount', { count: formData.name.length, max: 255 })}</p>
             </div>
 
             <div className="space-y-2">
@@ -144,11 +140,7 @@ export default function NewOrEditArticleCategory() {
 
             <div className="flex gap-4">
               <Button type="submit" disabled={loading}>
-                {loading
-                  ? t('common.status.saving')
-                  : isEditing
-                    ? t('articleCategory.actions.update')
-                    : t('articleCategory.actions.create')}
+                {loading ? t('common.status.saving') : isEditing ? t('articleCategory.actions.update') : t('articleCategory.actions.create')}
               </Button>
               <Button type="button" variant="outline" onClick={handleCancel}>
                 {t('common.actions.cancel')}

--- a/frontend/src/pages/admin/NewOrEditArticleSubCategory.tsx
+++ b/frontend/src/pages/admin/NewOrEditArticleSubCategory.tsx
@@ -8,12 +8,14 @@ import type { CreateArticleSubCategoryRequest, UpdateArticleSubCategoryRequest }
 import { articleCategoriesApi, articleSubCategoriesApi } from '@/lib/api';
 import type { ArticleCategory } from '@/types/mug';
 import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export default function NewOrEditArticleSubCategory() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const isEditing = !!id;
+  const { t } = useTranslation('admin');
 
   const [formData, setFormData] = useState<CreateArticleSubCategoryRequest>({
     articleCategoryId: 0,
@@ -31,9 +33,9 @@ export default function NewOrEditArticleSubCategory() {
       setCategories(data);
     } catch (error) {
       console.error('Error fetching article categories:', error);
-      setError('Failed to load article categories');
+      setError(t('articleSubCategory.errors.loadCategories'));
     }
-  }, []);
+  }, [t]);
 
   const fetchArticleSubCategory = useCallback(async () => {
     if (!id) return;
@@ -48,11 +50,11 @@ export default function NewOrEditArticleSubCategory() {
       });
     } catch (error) {
       console.error('Error fetching article subcategory:', error);
-      setError('Failed to load article subcategory');
+      setError(t('articleSubCategory.errors.load'));
     } finally {
       setInitialLoading(false);
     }
-  }, [id]);
+  }, [id, t]);
 
   useEffect(() => {
     fetchCategories();
@@ -67,12 +69,12 @@ export default function NewOrEditArticleSubCategory() {
     e.preventDefault();
 
     if (!formData.name.trim()) {
-      setError('Name is required');
+      setError(t('articleSubCategory.errors.nameRequired'));
       return;
     }
 
     if (!formData.articleCategoryId) {
-      setError('Category is required');
+      setError(t('articleSubCategory.errors.categoryRequired'));
       return;
     }
 
@@ -94,7 +96,7 @@ export default function NewOrEditArticleSubCategory() {
       navigate('/admin/article-subcategories');
     } catch (error) {
       console.error('Error saving article subcategory:', error);
-      setError('Failed to save article subcategory. Please try again.');
+      setError(t('articleSubCategory.errors.save'));
     } finally {
       setLoading(false);
     }
@@ -108,7 +110,7 @@ export default function NewOrEditArticleSubCategory() {
     return (
       <div className="container mx-auto p-6">
         <div className="flex h-64 items-center justify-center">
-          <p className="text-gray-500">Loading...</p>
+          <p className="text-gray-500">{t('common.loading')}</p>
         </div>
       </div>
     );
@@ -118,9 +120,9 @@ export default function NewOrEditArticleSubCategory() {
     <div className="container mx-auto p-6">
       <Card className="mx-auto max-w-2xl">
         <CardHeader>
-          <CardTitle>{isEditing ? 'Edit Article Subcategory' : 'New Article Subcategory'}</CardTitle>
+          <CardTitle>{isEditing ? t('articleSubCategory.title.edit') : t('articleSubCategory.title.new')}</CardTitle>
           <CardDescription>
-            {isEditing ? 'Update the article subcategory details below' : 'Create a new article subcategory with the form below'}
+            {isEditing ? t('articleSubCategory.description.edit') : t('articleSubCategory.description.new')}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -128,13 +130,13 @@ export default function NewOrEditArticleSubCategory() {
             {error && <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700">{error}</div>}
 
             <div className="space-y-2">
-              <Label htmlFor="category">Category</Label>
+              <Label htmlFor="category">{t('articleSubCategory.form.category')}</Label>
               <Select
                 value={formData.articleCategoryId.toString()}
                 onValueChange={(value) => setFormData({ ...formData, articleCategoryId: parseInt(value) })}
               >
                 <SelectTrigger id="category">
-                  <SelectValue placeholder="Select a category" />
+                  <SelectValue placeholder={t('articleSubCategory.form.categoryPlaceholder')} />
                 </SelectTrigger>
                 <SelectContent>
                   {categories.map((category) => (
@@ -147,33 +149,37 @@ export default function NewOrEditArticleSubCategory() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
+              <Label htmlFor="name">{t('articleSubCategory.form.name')}</Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                placeholder="Enter subcategory name"
+                placeholder={t('articleSubCategory.form.namePlaceholder')}
                 required
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="description">Description</Label>
+              <Label htmlFor="description">{t('articleSubCategory.form.description')}</Label>
               <Textarea
                 id="description"
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                placeholder="Enter subcategory description (optional)"
+                placeholder={t('articleSubCategory.form.descriptionPlaceholder')}
                 rows={3}
               />
             </div>
 
             <div className="flex gap-4">
               <Button type="submit" disabled={loading}>
-                {loading ? 'Saving...' : isEditing ? 'Update Subcategory' : 'Create Subcategory'}
+                {loading
+                  ? t('common.status.saving')
+                  : isEditing
+                    ? t('articleSubCategory.actions.update')
+                    : t('articleSubCategory.actions.create')}
               </Button>
               <Button type="button" variant="outline" onClick={handleCancel}>
-                Cancel
+                {t('common.actions.cancel')}
               </Button>
             </div>
           </form>

--- a/frontend/src/pages/admin/NewOrEditArticleSubCategory.tsx
+++ b/frontend/src/pages/admin/NewOrEditArticleSubCategory.tsx
@@ -121,9 +121,7 @@ export default function NewOrEditArticleSubCategory() {
       <Card className="mx-auto max-w-2xl">
         <CardHeader>
           <CardTitle>{isEditing ? t('articleSubCategory.title.edit') : t('articleSubCategory.title.new')}</CardTitle>
-          <CardDescription>
-            {isEditing ? t('articleSubCategory.description.edit') : t('articleSubCategory.description.new')}
-          </CardDescription>
+          <CardDescription>{isEditing ? t('articleSubCategory.description.edit') : t('articleSubCategory.description.new')}</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
@@ -172,11 +170,7 @@ export default function NewOrEditArticleSubCategory() {
 
             <div className="flex gap-4">
               <Button type="submit" disabled={loading}>
-                {loading
-                  ? t('common.status.saving')
-                  : isEditing
-                    ? t('articleSubCategory.actions.update')
-                    : t('articleSubCategory.actions.create')}
+                {loading ? t('common.status.saving') : isEditing ? t('articleSubCategory.actions.update') : t('articleSubCategory.actions.create')}
               </Button>
               <Button type="button" variant="outline" onClick={handleCancel}>
                 {t('common.actions.cancel')}

--- a/frontend/src/pages/admin/NewOrEditPrompt.tsx
+++ b/frontend/src/pages/admin/NewOrEditPrompt.tsx
@@ -397,7 +397,11 @@ export default function NewOrEditPrompt() {
                     <div className="space-y-3">
                       {exampleImageUrl ? (
                         <div className="relative w-full max-w-md">
-                          <img src={exampleImageUrl} alt={t('prompt.exampleImage.alt')} className="w-full rounded-lg border border-gray-200 object-contain" />
+                          <img
+                            src={exampleImageUrl}
+                            alt={t('prompt.exampleImage.alt')}
+                            className="w-full rounded-lg border border-gray-200 object-contain"
+                          />
                           <Button
                             type="button"
                             variant="outline"
@@ -447,11 +451,7 @@ export default function NewOrEditPrompt() {
         {/* Global action bar visible for both tabs */}
         <div className="mt-6 flex gap-4">
           <Button type="submit" form="prompt-form" disabled={loading}>
-            {loading
-              ? t('common.status.saving')
-              : isEditing
-                ? t('prompt.actions.update')
-                : t('prompt.actions.create')}
+            {loading ? t('common.status.saving') : isEditing ? t('prompt.actions.update') : t('prompt.actions.create')}
           </Button>
           <Button type="button" variant="outline" onClick={handleCancel}>
             {t('common.actions.cancel')}

--- a/frontend/src/pages/admin/NewOrEditPrompt.tsx
+++ b/frontend/src/pages/admin/NewOrEditPrompt.tsx
@@ -16,6 +16,7 @@ import { usePromptPriceStore } from '@/stores/admin/prompts/usePromptPriceStore'
 import type { PromptCategory, PromptSubCategory } from '@/types/prompt';
 import { Calculator, FileText, Upload, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import PriceCalculationTab from './prompts/components/PriceCalculationTab';
 // no extra API needed; prompt includes costCalculation
@@ -24,6 +25,7 @@ export default function NewOrEditPrompt() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const isEditing = !!id;
+  const { t } = useTranslation('admin');
 
   const [formData, setFormData] = useState({
     title: '',
@@ -53,9 +55,9 @@ export default function NewOrEditPrompt() {
       setCategories(data);
     } catch (error) {
       console.error('Error fetching categories:', error);
-      setError('Failed to load categories');
+      setError(t('prompt.errors.loadCategories'));
     }
-  }, []);
+  }, [t]);
 
   const fetchSubcategories = useCallback(async (categoryId: number) => {
     if (!categoryId) {
@@ -118,11 +120,11 @@ export default function NewOrEditPrompt() {
       }
     } catch (error) {
       console.error('Error fetching prompt:', error);
-      setError('Failed to load prompt');
+      setError(t('prompt.errors.load'));
     } finally {
       setInitialLoading(false);
     }
-  }, [fetchSubcategories, id, setCostCalculation]);
+  }, [fetchSubcategories, id, setCostCalculation, t]);
 
   useEffect(() => {
     fetchCategories();
@@ -146,13 +148,13 @@ export default function NewOrEditPrompt() {
     e.preventDefault();
 
     if (!formData.title.trim()) {
-      setError('Title is required');
+      setError(t('prompt.errors.titleRequired'));
       setActiveTab('prompt');
       return;
     }
 
     if (!formData.categoryId) {
-      setError('Category is required');
+      setError(t('prompt.errors.categoryRequired'));
       setActiveTab('prompt');
       return;
     }
@@ -170,8 +172,12 @@ export default function NewOrEditPrompt() {
           imageFilename = uploadResult.filename;
         } catch (uploadError: unknown) {
           console.error('Error uploading image:', uploadError);
-          const errorMessage = uploadError instanceof Error ? uploadError.message : 'Please try again.';
-          setError(`Failed to upload image: ${errorMessage}`);
+          const errorMessage = uploadError instanceof Error ? uploadError.message : '';
+          setError(
+            t('prompt.errors.uploadImage', {
+              message: errorMessage || t('common.errors.generic'),
+            }),
+          );
           setLoading(false);
           return;
         }
@@ -215,7 +221,7 @@ export default function NewOrEditPrompt() {
       navigate('/admin/prompts');
     } catch (error) {
       console.error('Error saving prompt:', error);
-      setError('Failed to save prompt. Please try again.');
+      setError(t('prompt.errors.save'));
     } finally {
       setLoading(false);
     }
@@ -228,14 +234,14 @@ export default function NewOrEditPrompt() {
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !file.type.startsWith('image/')) {
-      setError('Please select a valid image file');
+      setError(t('prompt.errors.invalidImage'));
       return;
     }
 
     // Check file size (10MB limit)
     const maxSize = 10 * 1024 * 1024;
     if (file.size > maxSize) {
-      setError('File size exceeds maximum allowed size of 10MB');
+      setError(t('prompt.errors.imageTooLarge'));
       return;
     }
 
@@ -270,7 +276,7 @@ export default function NewOrEditPrompt() {
     return (
       <div className="container mx-auto p-6">
         <div className="flex h-64 items-center justify-center">
-          <p className="text-gray-500">Loading...</p>
+          <p className="text-gray-500">{t('common.loading')}</p>
         </div>
       </div>
     );
@@ -283,37 +289,37 @@ export default function NewOrEditPrompt() {
           <TabsList className="grid w-full grid-cols-2 lg:w-auto lg:grid-flow-col">
             <TabsTrigger value="prompt" className="gap-2">
               <FileText className="h-4 w-4" />
-              <span className="hidden sm:inline">Prompt</span>
+              <span className="hidden sm:inline">{t('prompt.tabs.prompt')}</span>
             </TabsTrigger>
             <TabsTrigger value="cost-calculation" className="gap-2">
               <Calculator className="h-4 w-4" />
-              <span className="hidden sm:inline">Price Calculation</span>
+              <span className="hidden sm:inline">{t('prompt.tabs.costCalculation')}</span>
             </TabsTrigger>
           </TabsList>
 
           <TabsContent value="prompt" forceMount>
             <Card>
               <CardHeader>
-                <CardTitle>{isEditing ? 'Edit Prompt' : 'New Prompt'}</CardTitle>
-                <CardDescription>{isEditing ? 'Update the prompt details below' : 'Create a new prompt with the form below'}</CardDescription>
+                <CardTitle>{isEditing ? t('prompt.title.edit') : t('prompt.title.new')}</CardTitle>
+                <CardDescription>{isEditing ? t('prompt.description.edit') : t('prompt.description.new')}</CardDescription>
               </CardHeader>
               <CardContent>
                 <form id="prompt-form" onSubmit={handleSubmit} className="space-y-6">
                   {error && <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700">{error}</div>}
 
                   <div className="space-y-2">
-                    <Label htmlFor="title">Title</Label>
+                    <Label htmlFor="title">{t('prompt.form.title')}</Label>
                     <Input
                       id="title"
                       value={formData.title}
                       onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                      placeholder="Enter prompt title"
+                      placeholder={t('prompt.form.titlePlaceholder')}
                       required
                     />
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="promptNumber">Prompt Number</Label>
+                    <Label htmlFor="promptNumber">{t('prompt.form.promptNumber')}</Label>
                     <InputWithCopy
                       id="promptNumber"
                       value={
@@ -326,7 +332,7 @@ export default function NewOrEditPrompt() {
 
                   <div className="flex gap-8">
                     <div className="space-y-2">
-                      <Label htmlFor="category">Category</Label>
+                      <Label htmlFor="category">{t('prompt.form.category')}</Label>
                       <Select
                         value={formData.categoryId.toString()}
                         onValueChange={(value) => {
@@ -336,7 +342,7 @@ export default function NewOrEditPrompt() {
                         }}
                       >
                         <SelectTrigger id="category">
-                          <SelectValue placeholder="Select a category" />
+                          <SelectValue placeholder={t('prompt.form.categoryPlaceholder')} />
                         </SelectTrigger>
                         <SelectContent>
                           {categories.map((category) => (
@@ -350,16 +356,16 @@ export default function NewOrEditPrompt() {
 
                     {formData.categoryId > 0 && subcategories.length > 0 && (
                       <div className="space-y-2">
-                        <Label htmlFor="subcategory">Subcategory (optional)</Label>
+                        <Label htmlFor="subcategory">{t('prompt.form.subcategory')}</Label>
                         <Select
                           value={formData.subcategoryId.toString()}
                           onValueChange={(value) => setFormData({ ...formData, subcategoryId: parseInt(value) })}
                         >
                           <SelectTrigger id="subcategory">
-                            <SelectValue placeholder="Select a subcategory (optional)" />
+                            <SelectValue placeholder={t('prompt.form.subcategoryPlaceholder')} />
                           </SelectTrigger>
                           <SelectContent>
-                            <SelectItem value="0">No subcategory</SelectItem>
+                            <SelectItem value="0">{t('prompt.form.noSubcategory')}</SelectItem>
                             {subcategories.map((subcategory) => (
                               <SelectItem key={subcategory.id} value={subcategory.id.toString()}>
                                 {subcategory.name}
@@ -372,12 +378,12 @@ export default function NewOrEditPrompt() {
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="promptText">Prompt Style (optional)</Label>
+                    <Label htmlFor="promptText">{t('prompt.form.promptStyle')}</Label>
                     <Textarea
                       id="promptText"
                       value={formData.promptText}
                       onChange={(e) => setFormData({ ...formData, promptText: e.target.value })}
-                      placeholder="Enter the prompt text content..."
+                      placeholder={t('prompt.form.promptStylePlaceholder')}
                       rows={4}
                     />
                   </div>
@@ -387,11 +393,11 @@ export default function NewOrEditPrompt() {
                   </div>
 
                   <div className="space-y-2">
-                    <Label>Example Image (optional)</Label>
+                    <Label>{t('prompt.exampleImage.label')}</Label>
                     <div className="space-y-3">
                       {exampleImageUrl ? (
                         <div className="relative w-full max-w-md">
-                          <img src={exampleImageUrl} alt="Prompt example" className="w-full rounded-lg border border-gray-200 object-contain" />
+                          <img src={exampleImageUrl} alt={t('prompt.exampleImage.alt')} className="w-full rounded-lg border border-gray-200 object-contain" />
                           <Button
                             type="button"
                             variant="outline"
@@ -406,9 +412,9 @@ export default function NewOrEditPrompt() {
                         <div className="flex items-center gap-2">
                           <Button type="button" variant="outline" onClick={() => fileInputRef.current?.click()}>
                             <Upload className="mr-2 h-4 w-4" />
-                            Upload Image
+                            {t('common.actions.uploadImage')}
                           </Button>
-                          <p className="text-sm text-gray-500">PNG, JPG, GIF, or WEBP (automatically converted to WebP)</p>
+                          <p className="text-sm text-gray-500">{t('prompt.exampleImage.hint')}</p>
                         </div>
                       )}
                       <input ref={fileInputRef} type="file" accept="image/*" onChange={handleImageUpload} className="hidden" />
@@ -416,7 +422,7 @@ export default function NewOrEditPrompt() {
                   </div>
 
                   <div className="space-y-2">
-                    <Label htmlFor="active">Status</Label>
+                    <Label htmlFor="active">{t('prompt.form.status')}</Label>
                     <div className="flex items-center space-x-2">
                       <Checkbox
                         id="active"
@@ -424,7 +430,7 @@ export default function NewOrEditPrompt() {
                         onCheckedChange={(checked) => setFormData({ ...formData, active: checked as boolean })}
                       />
                       <Label htmlFor="active" className="font-normal">
-                        Make this prompt available for use
+                        {t('prompt.form.statusHint')}
                       </Label>
                     </div>
                   </div>
@@ -441,10 +447,14 @@ export default function NewOrEditPrompt() {
         {/* Global action bar visible for both tabs */}
         <div className="mt-6 flex gap-4">
           <Button type="submit" form="prompt-form" disabled={loading}>
-            {loading ? 'Saving...' : isEditing ? 'Update Prompt' : 'Create Prompt'}
+            {loading
+              ? t('common.status.saving')
+              : isEditing
+                ? t('prompt.actions.update')
+                : t('prompt.actions.create')}
           </Button>
           <Button type="button" variant="outline" onClick={handleCancel}>
-            Cancel
+            {t('common.actions.cancel')}
           </Button>
         </div>
       </div>

--- a/frontend/src/pages/admin/NewOrEditPromptSlotType.tsx
+++ b/frontend/src/pages/admin/NewOrEditPromptSlotType.tsx
@@ -138,11 +138,7 @@ export default function NewOrEditPromptSlotType() {
 
             <div className="flex gap-4">
               <Button type="submit" disabled={loading}>
-                {loading
-                  ? t('common.status.saving')
-                  : isEditing
-                    ? t('promptSlotType.actions.update')
-                    : t('promptSlotType.actions.create')}
+                {loading ? t('common.status.saving') : isEditing ? t('promptSlotType.actions.update') : t('promptSlotType.actions.create')}
               </Button>
               <Button type="button" variant="outline" onClick={handleCancel}>
                 {t('common.actions.cancel')}

--- a/frontend/src/pages/admin/NewOrEditPromptSlotType.tsx
+++ b/frontend/src/pages/admin/NewOrEditPromptSlotType.tsx
@@ -5,12 +5,14 @@ import { Label } from '@/components/ui/Label';
 import type { CreatePromptSlotTypeRequest, UpdatePromptSlotTypeRequest } from '@/lib/api';
 import { promptSlotTypesApi } from '@/lib/api';
 import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export default function NewOrEditPromptSlotType() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const isEditing = !!id;
+  const { t } = useTranslation('admin');
 
   const [formData, setFormData] = useState<CreatePromptSlotTypeRequest>({
     name: '',
@@ -49,11 +51,11 @@ export default function NewOrEditPromptSlotType() {
       });
     } catch (error) {
       console.error('Error fetching prompt slot type:', error);
-      setError('Failed to load prompt slot type');
+      setError(t('promptSlotType.errors.load'));
     } finally {
       setInitialLoading(false);
     }
-  }, [id]);
+  }, [id, t]);
 
   useEffect(() => {
     if (isEditing) {
@@ -68,7 +70,7 @@ export default function NewOrEditPromptSlotType() {
     e.preventDefault();
 
     if (!formData.name.trim()) {
-      setError('Name is required');
+      setError(t('promptSlotType.errors.nameRequired'));
       return;
     }
 
@@ -92,7 +94,7 @@ export default function NewOrEditPromptSlotType() {
       navigate('/admin/prompt-slot-types');
     } catch (error) {
       console.error('Error saving prompt slot type:', error);
-      setError('Failed to save prompt slot type. Please try again.');
+      setError(t('promptSlotType.errors.save'));
     } finally {
       setLoading(false);
     }
@@ -106,7 +108,7 @@ export default function NewOrEditPromptSlotType() {
     return (
       <div className="container mx-auto p-6">
         <div className="flex h-64 items-center justify-center">
-          <p className="text-gray-500">Loading...</p>
+          <p className="text-gray-500">{t('common.loading')}</p>
         </div>
       </div>
     );
@@ -116,30 +118,34 @@ export default function NewOrEditPromptSlotType() {
     <div className="container mx-auto p-6">
       <Card className="mx-auto max-w-2xl">
         <CardHeader>
-          <CardTitle>{isEditing ? 'Edit Slot Type' : 'New Slot Type'}</CardTitle>
-          <CardDescription>{isEditing ? 'Update the slot type details below' : 'Create a new slot type with the form below'}</CardDescription>
+          <CardTitle>{isEditing ? t('promptSlotType.title.edit') : t('promptSlotType.title.new')}</CardTitle>
+          <CardDescription>{isEditing ? t('promptSlotType.description.edit') : t('promptSlotType.description.new')}</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
             {error && <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700">{error}</div>}
 
             <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
+              <Label htmlFor="name">{t('promptSlotType.form.name')}</Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                placeholder="Enter slot type name"
+                placeholder={t('promptSlotType.form.namePlaceholder')}
                 required
               />
             </div>
 
             <div className="flex gap-4">
               <Button type="submit" disabled={loading}>
-                {loading ? 'Saving...' : isEditing ? 'Update Slot Type' : 'Create Slot Type'}
+                {loading
+                  ? t('common.status.saving')
+                  : isEditing
+                    ? t('promptSlotType.actions.update')
+                    : t('promptSlotType.actions.create')}
               </Button>
               <Button type="button" variant="outline" onClick={handleCancel}>
-                Cancel
+                {t('common.actions.cancel')}
               </Button>
             </div>
           </form>

--- a/frontend/src/pages/admin/NewOrEditPromptSlotVariant.tsx
+++ b/frontend/src/pages/admin/NewOrEditPromptSlotVariant.tsx
@@ -9,12 +9,14 @@ import { imagesApi, promptSlotTypesApi, promptSlotVariantsApi } from '@/lib/api'
 import type { PromptSlotType } from '@/types/promptSlotVariant';
 import { Trash2, Upload } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 
 export default function NewOrEditPromptSlotVariant() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const isEditing = !!id;
+  const { t } = useTranslation('admin');
 
   const [formData, setFormData] = useState<CreatePromptSlotVariantRequest>({
     name: '',
@@ -38,9 +40,9 @@ export default function NewOrEditPromptSlotVariant() {
       setPromptSlotTypes(data);
     } catch (error) {
       console.error('Error fetching prompt slot types:', error);
-      setError('Failed to load prompt slot types');
+      setError(t('promptSlotVariant.errors.loadTypes'));
     }
-  }, []);
+  }, [t]);
 
   const fetchSlot = useCallback(async () => {
     if (!id) return;
@@ -60,11 +62,11 @@ export default function NewOrEditPromptSlotVariant() {
       }
     } catch (error) {
       console.error('Error fetching slot:', error);
-      setError('Failed to load slot');
+      setError(t('promptSlotVariant.errors.load'));
     } finally {
       setInitialLoading(false);
     }
-  }, [id]);
+  }, [id, t]);
 
   useEffect(() => {
     fetchPromptSlotTypes();
@@ -88,17 +90,17 @@ export default function NewOrEditPromptSlotVariant() {
     e.preventDefault();
 
     if (!formData.name.trim()) {
-      setError('Name is required');
+      setError(t('promptSlotVariant.errors.nameRequired'));
       return;
     }
 
     if (!formData.promptSlotTypeId) {
-      setError('Prompt slot type is required');
+      setError(t('promptSlotVariant.errors.typeRequired'));
       return;
     }
 
     if (!formData.prompt.trim()) {
-      setError('Prompt is required');
+      setError(t('promptSlotVariant.errors.promptRequired'));
       return;
     }
 
@@ -116,7 +118,7 @@ export default function NewOrEditPromptSlotVariant() {
           finalImageFilename = response.filename;
         } catch (error) {
           console.error('Error uploading image:', error);
-          setError('Failed to upload image. Please try again.');
+          setError(t('promptSlotVariant.errors.uploadImage'));
           return;
         } finally {
           setUploadingImage(false);
@@ -148,7 +150,7 @@ export default function NewOrEditPromptSlotVariant() {
       navigate('/admin/slot-variants');
     } catch (error) {
       console.error('Error saving slot:', error);
-      setError('Failed to save slot. Please try again.');
+      setError(t('promptSlotVariant.errors.save'));
     } finally {
       setLoading(false);
     }
@@ -164,13 +166,13 @@ export default function NewOrEditPromptSlotVariant() {
 
     // Validate file type
     if (!file.type.startsWith('image/')) {
-      setError('Please upload an image file');
+      setError(t('promptSlotVariant.errors.invalidImage'));
       return;
     }
 
     // Validate file size (max 5MB)
     if (file.size > 5 * 1024 * 1024) {
-      setError('Image size must be less than 5MB');
+      setError(t('promptSlotVariant.errors.imageTooLarge'));
       return;
     }
 
@@ -208,7 +210,7 @@ export default function NewOrEditPromptSlotVariant() {
     return (
       <div className="container mx-auto p-6">
         <div className="flex h-64 items-center justify-center">
-          <p className="text-gray-500">Loading...</p>
+          <p className="text-gray-500">{t('common.loading')}</p>
         </div>
       </div>
     );
@@ -218,32 +220,32 @@ export default function NewOrEditPromptSlotVariant() {
     <div className="container mx-auto p-6">
       <Card className="mx-auto max-w-2xl">
         <CardHeader>
-          <CardTitle>{isEditing ? 'Edit Slot' : 'New Slot'}</CardTitle>
-          <CardDescription>{isEditing ? 'Update the slot details below' : 'Create a new slot with the form below'}</CardDescription>
+          <CardTitle>{isEditing ? t('promptSlotVariant.title.edit') : t('promptSlotVariant.title.new')}</CardTitle>
+          <CardDescription>{isEditing ? t('promptSlotVariant.description.edit') : t('promptSlotVariant.description.new')}</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
             {error && <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700">{error}</div>}
 
             <div className="space-y-2">
-              <Label htmlFor="name">Name</Label>
+              <Label htmlFor="name">{t('promptSlotVariant.form.name')}</Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                placeholder="Enter slot name"
+                placeholder={t('promptSlotVariant.form.namePlaceholder')}
                 required
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="promptSlotType">Prompt Slot Type</Label>
+              <Label htmlFor="promptSlotType">{t('promptSlotVariant.form.type')}</Label>
               <Select
                 value={formData.promptSlotTypeId.toString()}
                 onValueChange={(value) => setFormData({ ...formData, promptSlotTypeId: parseInt(value) })}
               >
                 <SelectTrigger id="promptSlotType">
-                  <SelectValue placeholder="Select a prompt slot type" />
+                  <SelectValue placeholder={t('promptSlotVariant.form.typePlaceholder')} />
                 </SelectTrigger>
                 <SelectContent>
                   {promptSlotTypes.map((type) => (
@@ -256,34 +258,34 @@ export default function NewOrEditPromptSlotVariant() {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="prompt">Prompt</Label>
+              <Label htmlFor="prompt">{t('promptSlotVariant.form.prompt')}</Label>
               <Textarea
                 id="prompt"
                 value={formData.prompt}
                 onChange={(e) => setFormData({ ...formData, prompt: e.target.value })}
-                placeholder="Enter the prompt text"
+                placeholder={t('promptSlotVariant.form.promptPlaceholder')}
                 rows={6}
                 required
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="description">Description</Label>
+              <Label htmlFor="description">{t('promptSlotVariant.form.description')}</Label>
               <Textarea
                 id="description"
                 value={formData.description || ''}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                placeholder="Enter an optional description for this slot"
+                placeholder={t('promptSlotVariant.form.descriptionPlaceholder')}
                 rows={3}
               />
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="exampleImage">Example Image</Label>
+              <Label htmlFor="exampleImage">{t('promptSlotVariant.form.exampleImage')}</Label>
               <div className="space-y-4">
                 {currentImageUrl ? (
                   <div className="relative inline-block">
-                    <img src={currentImageUrl} alt="Example" className="h-32 w-32 rounded-lg border object-cover" />
+                    <img src={currentImageUrl} alt={t('promptSlotVariant.form.exampleAlt')} className="h-32 w-32 rounded-lg border object-cover" />
                     <Button type="button" variant="destructive" size="icon" className="absolute -top-2 -right-2 h-8 w-8" onClick={handleRemoveImage}>
                       <Trash2 className="h-4 w-4" />
                     </Button>
@@ -296,9 +298,9 @@ export default function NewOrEditPromptSlotVariant() {
                       className="flex cursor-pointer items-center gap-2 rounded-lg border-2 border-dashed px-4 py-2 hover:border-gray-400"
                     >
                       <Upload className="h-4 w-4" />
-                      Upload Image
+                      {t('common.actions.uploadImage')}
                     </Label>
-                    <span className="text-sm text-gray-500">Optional example image for this slot</span>
+                    <span className="text-sm text-gray-500">{t('promptSlotVariant.form.exampleHint')}</span>
                   </div>
                 )}
               </div>
@@ -306,10 +308,16 @@ export default function NewOrEditPromptSlotVariant() {
 
             <div className="flex gap-4">
               <Button type="submit" disabled={loading || uploadingImage}>
-                {uploadingImage ? 'Uploading image...' : loading ? 'Saving...' : isEditing ? 'Update Slot' : 'Create Slot'}
+                {uploadingImage
+                  ? t('common.status.uploadingImage')
+                  : loading
+                    ? t('common.status.saving')
+                    : isEditing
+                      ? t('promptSlotVariant.actions.update')
+                      : t('promptSlotVariant.actions.create')}
               </Button>
               <Button type="button" variant="outline" onClick={handleCancel}>
-                Cancel
+                {t('common.actions.cancel')}
               </Button>
             </div>
           </form>

--- a/frontend/src/pages/admin/NewOrEditSupplier.tsx
+++ b/frontend/src/pages/admin/NewOrEditSupplier.tsx
@@ -8,6 +8,7 @@ import { useCreateSupplier, useSupplier, useUpdateSupplier } from '@/hooks/queri
 import type { CreateSupplierRequest, UpdateSupplierRequest } from '@/types/supplier';
 import { ArrowLeft } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -15,6 +16,7 @@ export default function NewOrEditSupplier() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const isEditing = !!id;
+  const { t } = useTranslation('admin');
 
   const [formData, setFormData] = useState<{
     name: string;
@@ -79,11 +81,11 @@ export default function NewOrEditSupplier() {
     const newErrors: Record<string, string> = {};
 
     if (formData.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
-      newErrors.email = 'Invalid email format';
+      newErrors.email = t('supplier.errors.invalidEmail');
     }
 
     if (formData.postalCode && (isNaN(Number(formData.postalCode)) || Number(formData.postalCode) <= 0)) {
-      newErrors.postalCode = 'Postal code must be a positive number';
+      newErrors.postalCode = t('supplier.errors.postalCode');
     }
 
     setErrors(newErrors);
@@ -125,7 +127,8 @@ export default function NewOrEditSupplier() {
       }
       navigate('/admin/suppliers');
     } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'An error occurred';
+      const fallbackMessage = t('common.errors.generic');
+      const errorMessage = error instanceof Error ? error.message : fallbackMessage;
       toast.error(errorMessage);
     }
   };
@@ -138,7 +141,7 @@ export default function NewOrEditSupplier() {
     return (
       <div className="container mx-auto p-6">
         <div className="flex h-64 items-center justify-center">
-          <p className="text-gray-500">Loading...</p>
+          <p className="text-gray-500">{t('common.loading')}</p>
         </div>
       </div>
     );
@@ -149,37 +152,37 @@ export default function NewOrEditSupplier() {
       <div className="mb-6">
         <button onClick={() => navigate('/admin/suppliers')} className="mb-4 flex items-center gap-2 text-gray-600 hover:text-gray-900">
           <ArrowLeft className="h-4 w-4" />
-          Back to Suppliers
+          {t('supplier.breadcrumb.back')}
         </button>
-        <h1 className="text-2xl font-bold">{isEditing ? 'Edit Supplier' : 'Create New Supplier'}</h1>
+        <h1 className="text-2xl font-bold">{isEditing ? t('supplier.title.edit') : t('supplier.title.new')}</h1>
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6">
         {/* Company Information */}
         <Card>
           <CardHeader>
-            <CardTitle>Company Information</CardTitle>
-            <CardDescription>Basic information about the supplier company</CardDescription>
+            <CardTitle>{t('supplier.sections.company.title')}</CardTitle>
+            <CardDescription>{t('supplier.sections.company.description')}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div>
-              <Label htmlFor="name">Company Name</Label>
+              <Label htmlFor="name">{t('supplier.form.name')}</Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                placeholder="e.g., ABC Supplies Ltd."
+                placeholder={t('supplier.form.namePlaceholder')}
               />
             </div>
 
             <div>
-              <Label htmlFor="website">Website</Label>
+              <Label htmlFor="website">{t('supplier.form.website')}</Label>
               <Input
                 id="website"
                 type="url"
                 value={formData.website}
                 onChange={(e) => setFormData({ ...formData, website: e.target.value })}
-                placeholder="e.g., https://www.example.com"
+                placeholder={t('supplier.form.websitePlaceholder')}
               />
             </div>
           </CardContent>
@@ -188,50 +191,50 @@ export default function NewOrEditSupplier() {
         {/* Contact Person */}
         <Card>
           <CardHeader>
-            <CardTitle>Contact Person</CardTitle>
-            <CardDescription>Primary contact person at the supplier</CardDescription>
+            <CardTitle>{t('supplier.sections.contact.title')}</CardTitle>
+            <CardDescription>{t('supplier.sections.contact.description')}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-4 md:grid-cols-3">
               <div>
-                <Label htmlFor="title">Title</Label>
+                <Label htmlFor="title">{t('supplier.form.title')}</Label>
                 <Input
                   id="title"
                   value={formData.title}
                   onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-                  placeholder="e.g., Mr., Ms., Dr."
+                  placeholder={t('supplier.form.titlePlaceholder')}
                 />
               </div>
 
               <div>
-                <Label htmlFor="firstName">First Name</Label>
+                <Label htmlFor="firstName">{t('supplier.form.firstName')}</Label>
                 <Input
                   id="firstName"
                   value={formData.firstName}
                   onChange={(e) => setFormData({ ...formData, firstName: e.target.value })}
-                  placeholder="e.g., John"
+                  placeholder={t('supplier.form.firstNamePlaceholder')}
                 />
               </div>
 
               <div>
-                <Label htmlFor="lastName">Last Name</Label>
+                <Label htmlFor="lastName">{t('supplier.form.lastName')}</Label>
                 <Input
                   id="lastName"
                   value={formData.lastName}
                   onChange={(e) => setFormData({ ...formData, lastName: e.target.value })}
-                  placeholder="e.g., Doe"
+                  placeholder={t('supplier.form.lastNamePlaceholder')}
                 />
               </div>
             </div>
 
             <div>
-              <Label htmlFor="email">Email</Label>
+              <Label htmlFor="email">{t('supplier.form.email')}</Label>
               <Input
                 id="email"
                 type="email"
                 value={formData.email}
                 onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                placeholder="e.g., contact@example.com"
+                placeholder={t('supplier.form.emailPlaceholder')}
                 className={errors.email ? 'border-red-500' : ''}
               />
               {errors.email && <p className="mt-1 text-sm text-red-500">{errors.email}</p>}
@@ -242,60 +245,60 @@ export default function NewOrEditSupplier() {
         {/* Address */}
         <Card>
           <CardHeader>
-            <CardTitle>Address</CardTitle>
-            <CardDescription>Physical address of the supplier</CardDescription>
+            <CardTitle>{t('supplier.sections.address.title')}</CardTitle>
+            <CardDescription>{t('supplier.sections.address.description')}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-4 md:grid-cols-2">
               <div>
-                <Label htmlFor="street">Street</Label>
+                <Label htmlFor="street">{t('supplier.form.street')}</Label>
                 <Input
                   id="street"
                   value={formData.street}
                   onChange={(e) => setFormData({ ...formData, street: e.target.value })}
-                  placeholder="e.g., Main Street"
+                  placeholder={t('supplier.form.streetPlaceholder')}
                 />
               </div>
 
               <div>
-                <Label htmlFor="houseNumber">House Number</Label>
+                <Label htmlFor="houseNumber">{t('supplier.form.houseNumber')}</Label>
                 <Input
                   id="houseNumber"
                   value={formData.houseNumber}
                   onChange={(e) => setFormData({ ...formData, houseNumber: e.target.value })}
-                  placeholder="e.g., 123"
+                  placeholder={t('supplier.form.houseNumberPlaceholder')}
                 />
               </div>
             </div>
 
             <div className="grid gap-4 md:grid-cols-3">
               <div>
-                <Label htmlFor="city">City</Label>
+                <Label htmlFor="city">{t('supplier.form.city')}</Label>
                 <Input
                   id="city"
                   value={formData.city}
                   onChange={(e) => setFormData({ ...formData, city: e.target.value })}
-                  placeholder="e.g., Berlin"
+                  placeholder={t('supplier.form.cityPlaceholder')}
                 />
               </div>
 
               <div>
-                <Label htmlFor="postalCode">Postal Code</Label>
+                <Label htmlFor="postalCode">{t('supplier.form.postalCode')}</Label>
                 <Input
                   id="postalCode"
                   value={formData.postalCode}
                   onChange={(e) => setFormData({ ...formData, postalCode: e.target.value })}
-                  placeholder="e.g., 10115"
+                  placeholder={t('supplier.form.postalCodePlaceholder')}
                   className={errors.postalCode ? 'border-red-500' : ''}
                 />
                 {errors.postalCode && <p className="mt-1 text-sm text-red-500">{errors.postalCode}</p>}
               </div>
 
               <div>
-                <Label htmlFor="country">Country</Label>
+                <Label htmlFor="country">{t('supplier.form.country')}</Label>
                 <Select value={formData.countryId || undefined} onValueChange={(value) => setFormData({ ...formData, countryId: value })}>
                   <SelectTrigger id="country">
-                    <SelectValue placeholder="Select a country" />
+                    <SelectValue placeholder={t('supplier.form.countryPlaceholder')} />
                   </SelectTrigger>
                   <SelectContent>
                     {countries?.map((country) => (
@@ -313,41 +316,41 @@ export default function NewOrEditSupplier() {
         {/* Phone Numbers */}
         <Card>
           <CardHeader>
-            <CardTitle>Phone Numbers</CardTitle>
-            <CardDescription>Contact phone numbers for the supplier</CardDescription>
+            <CardTitle>{t('supplier.sections.phone.title')}</CardTitle>
+            <CardDescription>{t('supplier.sections.phone.description')}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid gap-4 md:grid-cols-3">
               <div>
-                <Label htmlFor="phoneNumber1">Primary Phone</Label>
+                <Label htmlFor="phoneNumber1">{t('supplier.form.phoneNumber1')}</Label>
                 <Input
                   id="phoneNumber1"
                   type="tel"
                   value={formData.phoneNumber1}
                   onChange={(e) => setFormData({ ...formData, phoneNumber1: e.target.value })}
-                  placeholder="e.g., +49 30 12345678"
+                  placeholder={t('supplier.form.phoneNumber1Placeholder')}
                 />
               </div>
 
               <div>
-                <Label htmlFor="phoneNumber2">Secondary Phone</Label>
+                <Label htmlFor="phoneNumber2">{t('supplier.form.phoneNumber2')}</Label>
                 <Input
                   id="phoneNumber2"
                   type="tel"
                   value={formData.phoneNumber2}
                   onChange={(e) => setFormData({ ...formData, phoneNumber2: e.target.value })}
-                  placeholder="e.g., +49 30 87654321"
+                  placeholder={t('supplier.form.phoneNumber2Placeholder')}
                 />
               </div>
 
               <div>
-                <Label htmlFor="phoneNumber3">Mobile Phone</Label>
+                <Label htmlFor="phoneNumber3">{t('supplier.form.phoneNumber3')}</Label>
                 <Input
                   id="phoneNumber3"
                   type="tel"
                   value={formData.phoneNumber3}
                   onChange={(e) => setFormData({ ...formData, phoneNumber3: e.target.value })}
-                  placeholder="e.g., +49 170 1234567"
+                  placeholder={t('supplier.form.phoneNumber3Placeholder')}
                 />
               </div>
             </div>
@@ -357,7 +360,11 @@ export default function NewOrEditSupplier() {
         {/* Actions */}
         <div className="flex gap-3">
           <Button type="submit" disabled={createSupplierMutation.isPending || updateSupplierMutation.isPending}>
-            {createSupplierMutation.isPending || updateSupplierMutation.isPending ? 'Saving...' : isEditing ? 'Update Supplier' : 'Create Supplier'}
+            {createSupplierMutation.isPending || updateSupplierMutation.isPending
+              ? t('common.status.saving')
+              : isEditing
+                ? t('supplier.actions.update')
+                : t('supplier.actions.create')}
           </Button>
           <Button
             type="button"
@@ -365,7 +372,7 @@ export default function NewOrEditSupplier() {
             onClick={handleCancel}
             disabled={createSupplierMutation.isPending || updateSupplierMutation.isPending}
           >
-            Cancel
+            {t('common.actions.cancel')}
           </Button>
         </div>
       </form>

--- a/frontend/src/pages/admin/NewOrEditVat.tsx
+++ b/frontend/src/pages/admin/NewOrEditVat.tsx
@@ -8,6 +8,7 @@ import { useCreateVat, useUpdateVat, useVat } from '@/hooks/queries/useVat';
 import type { CreateValueAddedTaxRequest, UpdateValueAddedTaxRequest } from '@/types/vat';
 import { ArrowLeft } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -15,6 +16,7 @@ export default function NewOrEditVat() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const isEditing = !!id;
+  const { t } = useTranslation('admin');
 
   const [formData, setFormData] = useState({
     name: '',
@@ -43,15 +45,15 @@ export default function NewOrEditVat() {
     const newErrors: Record<string, string> = {};
 
     if (!formData.name.trim()) {
-      newErrors.name = 'Name is required';
+      newErrors.name = t('vatForm.errors.nameRequired');
     }
 
     if (!formData.percent) {
-      newErrors.percent = 'Percent is required';
+      newErrors.percent = t('vatForm.errors.percentRequired');
     } else {
       const percentNum = parseInt(formData.percent);
       if (isNaN(percentNum) || percentNum <= 0) {
-        newErrors.percent = 'Percent must be a positive number';
+        newErrors.percent = t('vatForm.errors.percentPositive');
       }
     }
 
@@ -84,7 +86,8 @@ export default function NewOrEditVat() {
       }
       navigate('/admin/vat');
     } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'An error occurred';
+      const fallbackMessage = t('common.errors.generic');
+      const errorMessage = error instanceof Error ? error.message : fallbackMessage;
       toast.error(errorMessage);
     }
   };
@@ -97,7 +100,7 @@ export default function NewOrEditVat() {
     return (
       <div className="container mx-auto p-6">
         <div className="flex h-64 items-center justify-center">
-          <p className="text-gray-500">Loading VAT data...</p>
+          <p className="text-gray-500">{t('vatForm.loading')}</p>
         </div>
       </div>
     );
@@ -108,38 +111,38 @@ export default function NewOrEditVat() {
       <div className="mb-6">
         <button onClick={() => navigate('/admin/vat')} className="mb-4 flex items-center gap-2 text-gray-600 hover:text-gray-900">
           <ArrowLeft className="h-4 w-4" />
-          Back to VAT List
+          {t('vatForm.breadcrumb.back')}
         </button>
-        <h1 className="text-2xl font-bold">{isEditing ? 'Edit VAT' : 'Create New VAT'}</h1>
+        <h1 className="text-2xl font-bold">{isEditing ? t('vatForm.title.edit') : t('vatForm.title.new')}</h1>
       </div>
 
       <Card className="max-w-2xl">
         <CardHeader>
-          <CardTitle>{isEditing ? 'Edit VAT Details' : 'VAT Details'}</CardTitle>
-          <CardDescription>{isEditing ? 'Update the VAT information below.' : 'Enter the details for the new VAT entry.'}</CardDescription>
+          <CardTitle>{isEditing ? t('vatForm.cardTitle.edit') : t('vatForm.cardTitle.new')}</CardTitle>
+          <CardDescription>{isEditing ? t('vatForm.cardDescription.edit') : t('vatForm.cardDescription.new')}</CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <Label htmlFor="name">Name *</Label>
+              <Label htmlFor="name">{t('vatForm.form.name')}</Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                placeholder="e.g., Standard VAT"
+                placeholder={t('vatForm.form.namePlaceholder')}
                 className={errors.name ? 'border-red-500' : ''}
               />
               {errors.name && <p className="mt-1 text-sm text-red-500">{errors.name}</p>}
             </div>
 
             <div>
-              <Label htmlFor="percent">Percent (%) *</Label>
+              <Label htmlFor="percent">{t('vatForm.form.percent')}</Label>
               <Input
                 id="percent"
                 type="number"
                 value={formData.percent}
                 onChange={(e) => setFormData({ ...formData, percent: e.target.value })}
-                placeholder="e.g., 19"
+                placeholder={t('vatForm.form.percentPlaceholder')}
                 min="1"
                 className={errors.percent ? 'border-red-500' : ''}
               />
@@ -147,12 +150,12 @@ export default function NewOrEditVat() {
             </div>
 
             <div>
-              <Label htmlFor="description">Description</Label>
+              <Label htmlFor="description">{t('vatForm.form.description')}</Label>
               <Textarea
                 id="description"
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                placeholder="Optional description for this VAT rate"
+                placeholder={t('vatForm.form.descriptionPlaceholder')}
                 rows={3}
               />
             </div>
@@ -164,16 +167,20 @@ export default function NewOrEditVat() {
                 onCheckedChange={(checked) => setFormData({ ...formData, isDefault: checked === true })}
               />
               <Label htmlFor="isDefault" className="cursor-pointer text-sm font-normal">
-                Set as default VAT
+                {t('vatForm.form.isDefault')}
               </Label>
             </div>
 
             <div className="flex gap-3 pt-4">
               <Button type="submit" disabled={createVatMutation.isPending || updateVatMutation.isPending}>
-                {createVatMutation.isPending || updateVatMutation.isPending ? 'Saving...' : isEditing ? 'Update VAT' : 'Create VAT'}
+                {createVatMutation.isPending || updateVatMutation.isPending
+                  ? t('common.status.saving')
+                  : isEditing
+                    ? t('vatForm.actions.update')
+                    : t('vatForm.actions.create')}
               </Button>
               <Button type="button" variant="outline" onClick={handleCancel} disabled={createVatMutation.isPending || updateVatMutation.isPending}>
-                Cancel
+                {t('common.actions.cancel')}
               </Button>
             </div>
           </form>

--- a/frontend/src/pages/admin/prompts/components/PriceCalculationTab.tsx
+++ b/frontend/src/pages/admin/prompts/components/PriceCalculationTab.tsx
@@ -6,8 +6,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useVats } from '@/hooks/queries/useVat';
 import { usePromptPriceStore } from '@/stores/admin/prompts/usePromptPriceStore';
 import { useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export default function PriceCalculationTab() {
+  const { t } = useTranslation('admin');
   const { data: vats = [] } = useVats();
 
   const {
@@ -84,16 +86,16 @@ export default function PriceCalculationTab() {
       {/* Purchase Section */}
       <Card>
         <CardHeader>
-          <CardTitle>Purchase</CardTitle>
-          <CardDescription>Purchase price and price calculations</CardDescription>
+          <CardTitle>{t('prompt.priceCalculation.purchase.title')}</CardTitle>
+          <CardDescription>{t('prompt.priceCalculation.purchase.description')}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Tax Rate */}
           <div className="grid grid-cols-4 items-center gap-4">
-            <FieldLabel optional>Tax Rate</FieldLabel>
+            <FieldLabel optional>{t('prompt.priceCalculation.purchase.taxRateLabel')}</FieldLabel>
             <Select value={costCalculation.purchaseVatRateId?.toString() || ''} onValueChange={handlePurchaseVatRateChange}>
               <SelectTrigger>
-                <SelectValue placeholder="Select VAT rate" />
+                <SelectValue placeholder={t('prompt.priceCalculation.purchase.taxRatePlaceholder')} />
               </SelectTrigger>
               <SelectContent>
                 {vats.map((vat) => (
@@ -103,7 +105,7 @@ export default function PriceCalculationTab() {
                 ))}
               </SelectContent>
             </Select>
-            <div className="text-muted-foreground col-span-2 text-sm">(from article or service group)</div>
+            <div className="text-muted-foreground col-span-2 text-sm">{t('prompt.priceCalculation.purchase.taxRateHint')}</div>
           </div>
 
           {/* Calculation Mode */}
@@ -117,7 +119,7 @@ export default function PriceCalculationTab() {
                 onChange={() => setPurchaseCalculationMode('NET')}
                 className="h-4 w-4"
               />
-              <span>Net</span>
+              <span>{t('prompt.priceCalculation.purchase.mode.net')}</span>
             </label>
             <label className="flex items-center space-x-2">
               <input
@@ -128,21 +130,21 @@ export default function PriceCalculationTab() {
                 onChange={() => setPurchaseCalculationMode('GROSS')}
                 className="h-4 w-4"
               />
-              <span>Gross</span>
+              <span>{t('prompt.priceCalculation.purchase.mode.gross')}</span>
             </label>
           </div>
 
           {/* Headers */}
           <div className="text-muted-foreground grid grid-cols-4 gap-4 text-sm font-medium">
             <div></div>
-            <div className="text-center">Net</div>
-            <div className="text-center">Tax</div>
-            <div className="text-center">Gross</div>
+            <div className="text-center">{t('prompt.priceCalculation.purchase.headers.net')}</div>
+            <div className="text-center">{t('prompt.priceCalculation.purchase.headers.tax')}</div>
+            <div className="text-center">{t('prompt.priceCalculation.purchase.headers.gross')}</div>
           </div>
 
           {/* Purchase Price */}
           <div className="grid grid-cols-4 items-center gap-4">
-            <FieldLabel optional>Purchase Price</FieldLabel>
+            <FieldLabel optional>{t('prompt.priceCalculation.purchase.priceLabel')}</FieldLabel>
             <CurrencyInput
               value={costCalculation.purchasePriceNet}
               onChange={(value) => updatePurchasePrice('net', value)}
@@ -171,7 +173,7 @@ export default function PriceCalculationTab() {
                 className="h-4 w-4"
               />
               <FieldLabel htmlFor="purchaseCostRadio" optional>
-                Purchase Cost
+                {t('prompt.priceCalculation.purchase.costLabel')}
               </FieldLabel>
             </div>
             <CurrencyInput
@@ -202,7 +204,7 @@ export default function PriceCalculationTab() {
                 className="h-4 w-4"
               />
               <FieldLabel htmlFor="purchaseCostPercentRadio" optional>
-                Purchase Cost %
+                {t('prompt.priceCalculation.purchase.costPercentLabel')}
               </FieldLabel>
             </div>
             <CurrencyInput
@@ -221,7 +223,7 @@ export default function PriceCalculationTab() {
 
           {/* Purchase Total */}
           <div className="grid grid-cols-4 items-center gap-4 font-semibold">
-            <FieldLabel>Purchase Total</FieldLabel>
+            <FieldLabel>{t('prompt.priceCalculation.purchase.totalLabel')}</FieldLabel>
             <CurrencyInput value={costCalculation.purchaseTotalNet} onChange={() => {}} disabled />
             <CurrencyInput value={costCalculation.purchaseTotalTax} onChange={() => {}} disabled />
             <CurrencyInput value={costCalculation.purchaseTotalGross} onChange={() => {}} disabled />
@@ -230,15 +232,15 @@ export default function PriceCalculationTab() {
           {/* Price corresponds selection */}
           <div className="flex flex-wrap items-center gap-2 pt-2">
             <FieldLabel htmlFor="purchasePriceCorresponds" className="text-sm font-normal" optional>
-              Price corresponds to
+              {t('prompt.priceCalculation.purchase.priceCorrespondsLabel')}
             </FieldLabel>
             <Select value={costCalculation.purchasePriceCorresponds} onValueChange={handlePurchasePriceCorrespondsChange}>
               <SelectTrigger id="purchasePriceCorresponds" className="w-32">
-                <SelectValue placeholder="Select" />
+                <SelectValue placeholder={t('prompt.priceCalculation.purchase.priceCorrespondsPlaceholder')} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="NET">Net</SelectItem>
-                <SelectItem value="GROSS">Gross</SelectItem>
+                <SelectItem value="NET">{t('prompt.priceCalculation.purchase.mode.net')}</SelectItem>
+                <SelectItem value="GROSS">{t('prompt.priceCalculation.purchase.mode.gross')}</SelectItem>
               </SelectContent>
             </Select>
             <Input
@@ -246,9 +248,9 @@ export default function PriceCalculationTab() {
               value={costCalculation.purchasePriceUnit}
               onChange={(e) => updateCostField('purchasePriceUnit', e.target.value)}
               className="w-32"
-              placeholder="1.00"
+              placeholder={t('prompt.priceCalculation.purchase.unitPlaceholder')}
             />
-            <span className="text-muted-foreground text-sm">Quantity unit(s) or packaging</span>
+            <span className="text-muted-foreground text-sm">{t('prompt.priceCalculation.purchase.unitHint')}</span>
           </div>
         </CardContent>
       </Card>
@@ -256,16 +258,16 @@ export default function PriceCalculationTab() {
       {/* Sales Section */}
       <Card>
         <CardHeader>
-          <CardTitle>Sales</CardTitle>
-          <CardDescription>Sales price and margin calculations</CardDescription>
+          <CardTitle>{t('prompt.priceCalculation.sales.title')}</CardTitle>
+          <CardDescription>{t('prompt.priceCalculation.sales.description')}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Tax Rate */}
           <div className="grid grid-cols-4 items-center gap-4">
-            <FieldLabel optional>Tax Rate</FieldLabel>
+            <FieldLabel optional>{t('prompt.priceCalculation.sales.taxRateLabel')}</FieldLabel>
             <Select value={costCalculation.salesVatRateId?.toString() || ''} onValueChange={handleSalesVatRateChange}>
               <SelectTrigger>
-                <SelectValue placeholder="Select VAT rate" />
+                <SelectValue placeholder={t('prompt.priceCalculation.sales.taxRatePlaceholder')} />
               </SelectTrigger>
               <SelectContent>
                 {vats.map((vat) => (
@@ -275,7 +277,7 @@ export default function PriceCalculationTab() {
                 ))}
               </SelectContent>
             </Select>
-            <div className="text-muted-foreground col-span-2 text-sm">(from article or service group)</div>
+            <div className="text-muted-foreground col-span-2 text-sm">{t('prompt.priceCalculation.sales.taxRateHint')}</div>
           </div>
 
           {/* Calculation Mode */}
@@ -289,7 +291,7 @@ export default function PriceCalculationTab() {
                 onChange={() => setSalesCalculationMode('NET')}
                 className="h-4 w-4"
               />
-              <span>Net</span>
+              <span>{t('prompt.priceCalculation.sales.mode.net')}</span>
             </label>
             <label className="flex items-center space-x-2">
               <input
@@ -300,16 +302,16 @@ export default function PriceCalculationTab() {
                 onChange={() => setSalesCalculationMode('GROSS')}
                 className="h-4 w-4"
               />
-              <span>Gross</span>
+              <span>{t('prompt.priceCalculation.sales.mode.gross')}</span>
             </label>
           </div>
 
           {/* Headers */}
           <div className="text-muted-foreground grid grid-cols-4 gap-4 text-sm font-medium">
             <div></div>
-            <div className="text-center">Net</div>
-            <div className="text-center">Tax</div>
-            <div className="text-center">Gross</div>
+            <div className="text-center">{t('prompt.priceCalculation.sales.headers.net')}</div>
+            <div className="text-center">{t('prompt.priceCalculation.sales.headers.tax')}</div>
+            <div className="text-center">{t('prompt.priceCalculation.sales.headers.gross')}</div>
           </div>
 
           {/* Margin */}
@@ -325,7 +327,7 @@ export default function PriceCalculationTab() {
                 className="h-4 w-4"
               />
               <FieldLabel htmlFor="salesMarginRadio" optional>
-                Margin
+                {t('prompt.priceCalculation.sales.marginLabel')}
               </FieldLabel>
             </div>
             <CurrencyInput
@@ -354,7 +356,7 @@ export default function PriceCalculationTab() {
                 className="h-4 w-4"
               />
               <FieldLabel htmlFor="salesMarginPercentRadio" optional>
-                Margin %
+                {t('prompt.priceCalculation.sales.marginPercentLabel')}
               </FieldLabel>
             </div>
             <CurrencyInput
@@ -382,7 +384,7 @@ export default function PriceCalculationTab() {
                 onChange={() => updateCostField('salesActiveRow', 'TOTAL')}
                 className="h-4 w-4"
               />
-              <FieldLabel htmlFor="salesTotalRadio">Sales Total</FieldLabel>
+              <FieldLabel htmlFor="salesTotalRadio">{t('prompt.priceCalculation.sales.totalLabel')}</FieldLabel>
             </div>
             <CurrencyInput
               value={costCalculation.salesTotalNet}
@@ -400,15 +402,15 @@ export default function PriceCalculationTab() {
           {/* Price corresponds selection */}
           <div className="flex flex-wrap items-center gap-2 pt-2">
             <FieldLabel htmlFor="salesPriceCorresponds" className="text-sm font-normal" optional>
-              Price corresponds to
+              {t('prompt.priceCalculation.sales.priceCorrespondsLabel')}
             </FieldLabel>
             <Select value={costCalculation.salesPriceCorresponds} onValueChange={handleSalesPriceCorrespondsChange}>
               <SelectTrigger id="salesPriceCorresponds" className="w-32">
-                <SelectValue placeholder="Select" />
+                <SelectValue placeholder={t('prompt.priceCalculation.sales.priceCorrespondsPlaceholder')} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="NET">Net</SelectItem>
-                <SelectItem value="GROSS">Gross</SelectItem>
+                <SelectItem value="NET">{t('prompt.priceCalculation.sales.mode.net')}</SelectItem>
+                <SelectItem value="GROSS">{t('prompt.priceCalculation.sales.mode.gross')}</SelectItem>
               </SelectContent>
             </Select>
             <Input
@@ -416,9 +418,9 @@ export default function PriceCalculationTab() {
               value={costCalculation.salesPriceUnit}
               onChange={(e) => updateCostField('salesPriceUnit', e.target.value)}
               className="w-32"
-              placeholder="1.00"
+              placeholder={t('prompt.priceCalculation.sales.unitPlaceholder')}
             />
-            <span className="text-muted-foreground text-sm">Quantity unit(s) or packaging</span>
+            <span className="text-muted-foreground text-sm">{t('prompt.priceCalculation.sales.unitHint')}</span>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- add an `admin` translation namespace for English and German strings used across admin new/edit flows
- localize all admin new/edit pages and shared prompt components to read from the translation catalog
- update the prompt price calculation tab and slot selector to surface translated labels, placeholders, and feedback
- split the admin translation resources into per-page JSON modules for easier maintenance

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cb1ec7f7248321a7dd7ca8c447c763