### PR TITLE
Translate admin article forms

### DIFF
--- a/frontend/src/locales/de/admin-articles.json
+++ b/frontend/src/locales/de/admin-articles.json
@@ -1,49 +1,310 @@
 {
-  "page": {
-    "title": "Artikel",
-    "subtitle": "Verwalte deinen Produktkatalog",
-    "loading": "Artikel werden geladen...",
-    "empty": {
-      "description": "Keine Artikel gefunden",
-      "cta": "Lege deinen ersten Artikel an"
-    },
-    "filter": {
-      "label": "Filter",
-      "placeholder": "Nach Typ filtern",
-      "all": "Alle Typen",
-      "mug": "Tassen",
-      "shirt": "T-Shirts"
-    },
-    "actions": {
-      "new": "Neuer Artikel",
-      "edit": "Artikel bearbeiten",
-      "delete": "Artikel löschen"
-    },
-    "status": {
-      "active": "Aktiv",
-      "inactive": "Inaktiv"
-    },
-    "variantsHeading": "Varianten",
-    "confirmation": "Möchtest du diesen Artikel wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
-    "imageAlt": "Bildvorschau von {{name}}"
+  "articleTypes": {
+    "MUG": "Tasse",
+    "SHIRT": "T-Shirt"
   },
   "badges": {
     "variants": "{{count}} Variante",
     "variants_plural": "{{count}} Varianten"
   },
-  "articleTypes": {
-    "MUG": "Tasse",
-    "SHIRT": "T-Shirt"
+  "form": {
+    "actions": {
+      "create": "Artikel erstellen",
+      "update": "Artikel aktualisieren"
+    },
+    "breadcrumb": {
+      "editArticle": "Artikel bearbeiten",
+      "newArticle": "Neuer Artikel"
+    },
+    "common": {
+      "actions": "Aktionen",
+      "active": "Aktiv",
+      "add": "Hinzufügen",
+      "default": "Standard",
+      "gross": "Brutto",
+      "inactive": "Inaktiv",
+      "net": "Netto",
+      "select": "Auswählen",
+      "tax": "Steuer",
+      "unitPlaceholder": "1,00",
+      "yes": "Ja"
+    },
+    "general": {
+      "articleType": {
+        "description": "Wähle den Produkttyp, den du erstellen möchtest",
+        "placeholder": "Artikeltyp auswählen",
+        "title": "Artikeltyp"
+      },
+      "basicInformation": {
+        "description": "Wichtige Stammdaten zu deinem Artikel",
+        "fields": {
+          "active": "Aktiv",
+          "descriptionLong": {
+            "label": "Ausführliche Beschreibung",
+            "placeholder": "Komplette Produktbeschreibung mit Eigenschaften und Vorteilen"
+          },
+          "descriptionShort": {
+            "label": "Kurzbeschreibung",
+            "placeholder": "Kurzer Beschreibungstext für Produktlisten"
+          },
+          "name": {
+            "label": "Artikelname",
+            "placeholder": "z. B. Premium Kaffeetasse"
+          }
+        },
+        "title": "Basisinformationen"
+      },
+      "organization": {
+        "description": "Ordne deinen Artikel Kategorien und Lieferanten zu",
+        "fields": {
+          "articleNumber": {
+            "label": "Artikelnummer"
+          },
+          "category": {
+            "label": "Kategorie",
+            "placeholder": "Kategorie auswählen"
+          },
+          "subcategory": {
+            "disabledPlaceholder": "Zuerst Kategorie wählen",
+            "label": "Unterkategorie",
+            "placeholder": "Unterkategorie auswählen"
+          },
+          "supplier": {
+            "label": "Lieferant",
+            "none": "Kein Lieferant",
+            "placeholder": "Lieferant auswählen (optional)"
+          },
+          "supplierArticleName": {
+            "label": "Lieferantenartikelname",
+            "placeholder": "z. B. Premium Keramiktasse"
+          },
+          "supplierArticleNumber": {
+            "label": "Lieferantenartikelnummer",
+            "placeholder": "z. B. SKU-12345"
+          }
+        },
+        "title": "Organisation"
+      }
+    },
+    "header": {
+      "createTitle": "Neuen Artikel erstellen",
+      "defaultType": "Artikel",
+      "editTitle": "{{type}} bearbeiten"
+    },
+    "mugDetails": {
+      "description": "Physische Maße und Eigenschaften",
+      "documentFormat": {
+        "description": "Optionale Maße für die PDF-Erstellung.",
+        "title": "Dokumentenformat"
+      },
+      "fields": {
+        "diameter": {
+          "label": "Durchmesser ({{unit}})",
+          "placeholder": "82"
+        },
+        "dishwasherSafe": "Spülmaschinengeeignet",
+        "documentHeight": {
+          "label": "Dokumenthöhe ({{unit}})",
+          "placeholder": "z. B. 120"
+        },
+        "documentMargin": {
+          "label": "Unterer Rand ({{unit}})",
+          "placeholder": "z. B. 10"
+        },
+        "documentWidth": {
+          "label": "Dokumentbreite ({{unit}})",
+          "placeholder": "z. B. 250"
+        },
+        "fillingQuantity": {
+          "label": "Füllmenge",
+          "placeholder": "250ml"
+        },
+        "height": {
+          "label": "Höhe ({{unit}})",
+          "placeholder": "95"
+        },
+        "printTemplateHeight": {
+          "label": "Druckvorlagenhöhe ({{unit}})",
+          "placeholder": "80"
+        },
+        "printTemplateWidth": {
+          "label": "Druckvorlagenbreite ({{unit}})",
+          "placeholder": "200"
+        }
+      },
+      "title": "Tassenspezifikationen",
+      "validation": {
+        "documentHeightLarger": "Die Dokumenthöhe sollte größer sein als die Höhe der Druckvorlage",
+        "documentHeightPositive": "Die Dokumenthöhe muss positiv sein",
+        "documentMarginRange": "Der untere Rand muss zwischen 0-100 mm liegen",
+        "documentWidthLarger": "Die Dokumentbreite sollte größer sein als die Breite der Druckvorlage",
+        "documentWidthPositive": "Die Dokumentbreite muss positiv sein"
+      }
+    },
+    "mugVariants": {
+      "actions": {
+        "add": "Variante hinzufügen",
+        "copy": "Varianten kopieren"
+      },
+      "confirmation": {
+        "confirm": "Variante löschen",
+        "description": "Möchtest du diese Tassenvariante wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "title": "Tassenvariante löschen"
+      },
+      "description": "Füge unterschiedliche Farbkombinationen für diese Tasse hinzu. Jede Variante kann Innen- und Außenfarbe kombinieren.",
+      "imageAlt": "Beispielbild für {{name}}",
+      "info": {
+        "unsavedNotice": "Diese Varianten werden gespeichert, sobald du den Artikel speicherst."
+      },
+      "table": {
+        "articleVariantNumber": "Artikelvariantennummer",
+        "exampleImage": "Beispielbild",
+        "insideColor": "Innenfarbe",
+        "name": "Name",
+        "outsideColor": "Außenfarbe"
+      },
+      "title": "Tassenvarianten",
+      "toasts": {
+        "deleteError": "Variante konnte nicht gelöscht werden",
+        "deleted": "Variante erfolgreich gelöscht",
+        "removed": "Variante entfernt",
+        "saveBeforeCopy": "Bitte speichere den Artikel, bevor du Varianten kopierst"
+      }
+    },
+    "price": {
+      "common": {
+        "priceCorresponds": "Preis bezieht sich auf",
+        "quantityHelper": "Mengeneinheit oder Verpackung",
+        "vatHelper": "(aus Artikel oder Leistungsgruppe)",
+        "vatLabel": "Steuersatz",
+        "vatPlaceholder": "Steuersatz auswählen"
+      },
+      "purchase": {
+        "description": "Einkaufspreise und Berechnungen",
+        "fields": {
+          "cost": "Einkaufskosten",
+          "costPercent": "Einkaufskosten %",
+          "price": "Einkaufspreis",
+          "total": "Einkauf gesamt"
+        },
+        "title": "Einkauf"
+      },
+      "sales": {
+        "description": "Verkaufspreise und Margenberechnungen",
+        "fields": {
+          "margin": "Marge",
+          "marginPercent": "Marge %",
+          "total": "Verkauf gesamt"
+        },
+        "title": "Verkauf"
+      }
+    },
+    "shirtDetails": {
+      "description": "Material- und Größenangaben",
+      "fields": {
+        "availableSizes": {
+          "label": "Verfügbare Größen"
+        },
+        "careInstructions": {
+          "label": "Pflegehinweise",
+          "placeholder": "Maschinenwäsche kalt, trocknen bei niedriger Temperatur"
+        },
+        "fitType": {
+          "label": "Passform",
+          "options": {
+            "loose": "Locker",
+            "regular": "Regulär",
+            "slim": "Schmal"
+          },
+          "placeholder": "Passform auswählen"
+        },
+        "material": {
+          "label": "Material",
+          "placeholder": "100 % Baumwolle"
+        }
+      },
+      "title": "Shirt-Details"
+    },
+    "shirtVariants": {
+      "description": "Füge Farb- und Größenkombinationen für dieses Shirt hinzu. Jede Kombination bildet eine eigene Produktvariante.",
+      "fields": {
+        "color": {
+          "label": "Farbe",
+          "placeholder": "z. B. Schwarz"
+        },
+        "exampleImage": {
+          "label": "Beispielbild",
+          "placeholder": "bild.jpg"
+        },
+        "size": {
+          "label": "Größe"
+        }
+      },
+      "info": {
+        "unsavedNotice": "Diese Varianten werden gespeichert, sobald du den Artikel speicherst."
+      },
+      "table": {
+        "color": "Farbe",
+        "exampleImage": "Beispielbild",
+        "size": "Größe"
+      },
+      "title": "Shirt-Varianten",
+      "toasts": {
+        "addError": "Variante konnte nicht hinzugefügt werden",
+        "added": "Variante erfolgreich hinzugefügt",
+        "addedTemporary": "Variante hinzugefügt (wird mit dem Artikel gespeichert)",
+        "colorRequired": "Bitte gib eine Farbe ein",
+        "deleteError": "Variante konnte nicht gelöscht werden",
+        "deleted": "Variante erfolgreich gelöscht",
+        "duplicate": "Diese Kombination aus Farbe und Größe existiert bereits",
+        "removed": "Variante entfernt"
+      }
+    },
+    "tabs": {
+      "general": "Allgemein",
+      "mugDetails": "Tassendetails",
+      "priceCalculation": "Preiskalkulation",
+      "shirtDetails": "Shirt-Details",
+      "variants": "Varianten"
+    }
   },
-  "variants": {
-    "none": "Keine Varianten vorhanden",
-    "default": "Standard",
-    "inside": "Innen",
-    "outside": "Außen",
-    "size": "Größe {{size}}",
-    "colorAlt": "Variante {{color}}"
+  "page": {
+    "actions": {
+      "delete": "Artikel löschen",
+      "edit": "Artikel bearbeiten",
+      "new": "Neuer Artikel"
+    },
+    "confirmation": "Möchtest du diesen Artikel wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "empty": {
+      "cta": "Lege deinen ersten Artikel an",
+      "description": "Keine Artikel gefunden"
+    },
+    "filter": {
+      "all": "Alle Typen",
+      "label": "Filter",
+      "mug": "Tassen",
+      "placeholder": "Nach Typ filtern",
+      "shirt": "T-Shirts"
+    },
+    "imageAlt": "Bildvorschau von {{name}}",
+    "loading": "Artikel werden geladen...",
+    "status": {
+      "active": "Aktiv",
+      "inactive": "Inaktiv"
+    },
+    "subtitle": "Verwalte deinen Produktkatalog",
+    "title": "Artikel",
+    "variantsHeading": "Varianten"
   },
   "supplier": {
     "unknown": "-"
+  },
+  "variants": {
+    "colorAlt": "Variante {{color}}",
+    "default": "Standard",
+    "inside": "Innen",
+    "none": "Keine Varianten vorhanden",
+    "outside": "Außen",
+    "size": "Größe {{size}}"
   }
 }

--- a/frontend/src/locales/en/admin-articles.json
+++ b/frontend/src/locales/en/admin-articles.json
@@ -1,49 +1,310 @@
 {
-  "page": {
-    "title": "Articles",
-    "subtitle": "Manage your product catalog",
-    "loading": "Loading articles...",
-    "empty": {
-      "description": "No articles found",
-      "cta": "Add your first article"
-    },
-    "filter": {
-      "label": "Filter",
-      "placeholder": "Filter by type",
-      "all": "All Types",
-      "mug": "Mugs",
-      "shirt": "T-Shirts"
-    },
-    "actions": {
-      "new": "New Article",
-      "edit": "Edit article",
-      "delete": "Delete article"
-    },
-    "status": {
-      "active": "Active",
-      "inactive": "Inactive"
-    },
-    "variantsHeading": "Variants",
-    "confirmation": "Are you sure you want to delete this article? This action cannot be undone.",
-    "imageAlt": "Image preview of {{name}}"
+  "articleTypes": {
+    "MUG": "Mug",
+    "SHIRT": "T-Shirt"
   },
   "badges": {
     "variants": "{{count}} variant",
     "variants_plural": "{{count}} variants"
   },
-  "articleTypes": {
-    "MUG": "Mug",
-    "SHIRT": "T-Shirt"
+  "form": {
+    "actions": {
+      "create": "Create Article",
+      "update": "Update Article"
+    },
+    "breadcrumb": {
+      "editArticle": "Edit Article",
+      "newArticle": "New Article"
+    },
+    "common": {
+      "actions": "Actions",
+      "active": "Active",
+      "add": "Add",
+      "default": "Default",
+      "gross": "Gross",
+      "inactive": "Inactive",
+      "net": "Net",
+      "select": "Select",
+      "tax": "Tax",
+      "unitPlaceholder": "1.00",
+      "yes": "Yes"
+    },
+    "general": {
+      "articleType": {
+        "description": "Choose the type of product you want to create",
+        "placeholder": "Select article type",
+        "title": "Article Type"
+      },
+      "basicInformation": {
+        "description": "Essential details about your article",
+        "fields": {
+          "active": "Active",
+          "descriptionLong": {
+            "label": "Detailed Description",
+            "placeholder": "Full product description with features and benefits"
+          },
+          "descriptionShort": {
+            "label": "Short Description",
+            "placeholder": "Brief description for product listings"
+          },
+          "name": {
+            "label": "Article Name",
+            "placeholder": "e.g., Premium Coffee Mug"
+          }
+        },
+        "title": "Basic Information"
+      },
+      "organization": {
+        "description": "Categorize and organize your article",
+        "fields": {
+          "articleNumber": {
+            "label": "Article Number"
+          },
+          "category": {
+            "label": "Category",
+            "placeholder": "Select a category"
+          },
+          "subcategory": {
+            "disabledPlaceholder": "Select category first",
+            "label": "Subcategory",
+            "placeholder": "Select a subcategory"
+          },
+          "supplier": {
+            "label": "Supplier",
+            "none": "No supplier",
+            "placeholder": "Select a supplier (optional)"
+          },
+          "supplierArticleName": {
+            "label": "Supplier Article Name",
+            "placeholder": "e.g., Premium Ceramic Mug"
+          },
+          "supplierArticleNumber": {
+            "label": "Supplier Article Number",
+            "placeholder": "e.g., SKU-12345"
+          }
+        },
+        "title": "Organization"
+      }
+    },
+    "header": {
+      "createTitle": "Create New Article",
+      "defaultType": "Article",
+      "editTitle": "Edit {{type}}"
+    },
+    "mugDetails": {
+      "description": "Physical dimensions and properties",
+      "documentFormat": {
+        "description": "Optional dimensions for PDF generation.",
+        "title": "Document Format"
+      },
+      "fields": {
+        "diameter": {
+          "label": "Diameter ({{unit}})",
+          "placeholder": "82"
+        },
+        "dishwasherSafe": "Dishwasher Safe",
+        "documentHeight": {
+          "label": "Document Height ({{unit}})",
+          "placeholder": "e.g. 120"
+        },
+        "documentMargin": {
+          "label": "Bottom Margin ({{unit}})",
+          "placeholder": "e.g. 10"
+        },
+        "documentWidth": {
+          "label": "Document Width ({{unit}})",
+          "placeholder": "e.g. 250"
+        },
+        "fillingQuantity": {
+          "label": "Filling Quantity",
+          "placeholder": "250ml"
+        },
+        "height": {
+          "label": "Height ({{unit}})",
+          "placeholder": "95"
+        },
+        "printTemplateHeight": {
+          "label": "Print Template Height ({{unit}})",
+          "placeholder": "80"
+        },
+        "printTemplateWidth": {
+          "label": "Print Template Width ({{unit}})",
+          "placeholder": "200"
+        }
+      },
+      "title": "Mug Specifications",
+      "validation": {
+        "documentHeightLarger": "Document height should be greater than print template height",
+        "documentHeightPositive": "Document height must be positive",
+        "documentMarginRange": "Bottom margin should be between 0-100mm",
+        "documentWidthLarger": "Document width should be greater than print template width",
+        "documentWidthPositive": "Document width must be positive"
+      }
+    },
+    "mugVariants": {
+      "actions": {
+        "add": "Add Variant",
+        "copy": "Copy Variants"
+      },
+      "confirmation": {
+        "confirm": "Delete Variant",
+        "description": "Are you sure you want to delete this mug variant? This action cannot be undone.",
+        "title": "Delete Mug Variant"
+      },
+      "description": "Add different color combinations for this mug. Each variant can have different inside and outside colors.",
+      "imageAlt": "Example image for {{name}}",
+      "info": {
+        "unsavedNotice": "These variants will be saved when you save the article."
+      },
+      "table": {
+        "articleVariantNumber": "Article Variant Number",
+        "exampleImage": "Example Image",
+        "insideColor": "Inside Color",
+        "name": "Name",
+        "outsideColor": "Outside Color"
+      },
+      "title": "Mug Variants",
+      "toasts": {
+        "deleteError": "Failed to delete variant",
+        "deleted": "Variant deleted successfully",
+        "removed": "Variant removed",
+        "saveBeforeCopy": "Please save the article first before copying variants"
+      }
+    },
+    "price": {
+      "common": {
+        "priceCorresponds": "Price corresponds to",
+        "quantityHelper": "Quantity unit(s) or packaging",
+        "vatHelper": "(from article or service group)",
+        "vatLabel": "Tax Rate",
+        "vatPlaceholder": "Select VAT rate"
+      },
+      "purchase": {
+        "description": "Purchase price and price calculations",
+        "fields": {
+          "cost": "Purchase Cost",
+          "costPercent": "Purchase Cost %",
+          "price": "Purchase Price",
+          "total": "Purchase Total"
+        },
+        "title": "Purchase"
+      },
+      "sales": {
+        "description": "Sales price and margin calculations",
+        "fields": {
+          "margin": "Margin",
+          "marginPercent": "Margin %",
+          "total": "Sales Total"
+        },
+        "title": "Sales"
+      }
+    },
+    "shirtDetails": {
+      "description": "Material and sizing information",
+      "fields": {
+        "availableSizes": {
+          "label": "Available Sizes"
+        },
+        "careInstructions": {
+          "label": "Care Instructions",
+          "placeholder": "Machine wash cold, tumble dry low"
+        },
+        "fitType": {
+          "label": "Fit Type",
+          "options": {
+            "loose": "Loose",
+            "regular": "Regular",
+            "slim": "Slim"
+          },
+          "placeholder": "Select fit type"
+        },
+        "material": {
+          "label": "Material",
+          "placeholder": "100% Cotton"
+        }
+      },
+      "title": "Shirt Details"
+    },
+    "shirtVariants": {
+      "description": "Add color and size combinations for this shirt. Each combination represents a unique product variant.",
+      "fields": {
+        "color": {
+          "label": "Color",
+          "placeholder": "e.g., Black"
+        },
+        "exampleImage": {
+          "label": "Example Image",
+          "placeholder": "image.jpg"
+        },
+        "size": {
+          "label": "Size"
+        }
+      },
+      "info": {
+        "unsavedNotice": "These variants will be saved when you save the article."
+      },
+      "table": {
+        "color": "Color",
+        "exampleImage": "Example Image",
+        "size": "Size"
+      },
+      "title": "Shirt Variants",
+      "toasts": {
+        "addError": "Failed to add variant",
+        "added": "Variant added successfully",
+        "addedTemporary": "Variant added (will be saved with article)",
+        "colorRequired": "Please enter a color",
+        "deleteError": "Failed to delete variant",
+        "deleted": "Variant deleted successfully",
+        "duplicate": "This color and size combination already exists",
+        "removed": "Variant removed"
+      }
+    },
+    "tabs": {
+      "general": "General",
+      "mugDetails": "Mug Details",
+      "priceCalculation": "Price Calculation",
+      "shirtDetails": "Shirt Details",
+      "variants": "Variants"
+    }
   },
-  "variants": {
-    "none": "No variants available",
-    "default": "Default",
-    "inside": "Inside",
-    "outside": "Outside",
-    "size": "Size {{size}}",
-    "colorAlt": "{{color}} variant"
+  "page": {
+    "actions": {
+      "delete": "Delete article",
+      "edit": "Edit article",
+      "new": "New Article"
+    },
+    "confirmation": "Are you sure you want to delete this article? This action cannot be undone.",
+    "empty": {
+      "cta": "Add your first article",
+      "description": "No articles found"
+    },
+    "filter": {
+      "all": "All Types",
+      "label": "Filter",
+      "mug": "Mugs",
+      "placeholder": "Filter by type",
+      "shirt": "T-Shirts"
+    },
+    "imageAlt": "Image preview of {{name}}",
+    "loading": "Loading articles...",
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "subtitle": "Manage your product catalog",
+    "title": "Articles",
+    "variantsHeading": "Variants"
   },
   "supplier": {
     "unknown": "-"
+  },
+  "variants": {
+    "colorAlt": "{{color}} variant",
+    "default": "Default",
+    "inside": "Inside",
+    "none": "No variants available",
+    "outside": "Outside",
+    "size": "Size {{size}}"
   }
 }

--- a/frontend/src/pages/admin/articles/NewOrEditArticle.tsx
+++ b/frontend/src/pages/admin/articles/NewOrEditArticle.tsx
@@ -4,6 +4,7 @@ import { useArticleForm } from '@/hooks/useArticleForm';
 import { useArticleFormStore } from '@/stores/admin/articles/useArticleFormStore';
 import { ArrowLeft, Calculator, ChevronRight, Coffee, FileText, Layers, Loader2, Package, Save, Shirt } from 'lucide-react';
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import GeneralTab from './components/GeneralTab';
 import PriceCalculationTab from './components/PriceCalculationTab';
@@ -21,6 +22,7 @@ export default function NewOrEditArticle() {
   const location = useLocation();
   const { id } = useParams();
   const articleId = id ? Number(id) : undefined;
+  const { t } = useTranslation('adminArticles');
 
   // Use the new consolidated store
   const { article, activeTab, setActiveTab, initializeForm, resetForm, updateShirtDetails } = useArticleFormStore();
@@ -75,6 +77,7 @@ export default function NewOrEditArticle() {
 
   const ArticleIcon = article.articleType ? articleTypeIcons[article.articleType] : Package;
   const isEdit = !!articleId;
+  const articleTypeLabel = article.articleType ? t(`articleTypes.${article.articleType}`) : t('form.header.defaultType');
 
   return (
     <div className="bg-background min-h-screen">
@@ -86,16 +89,16 @@ export default function NewOrEditArticle() {
             <div className="flex items-center gap-2 text-sm">
               <Button variant="ghost" size="sm" onClick={() => navigate('/admin/articles')} className="gap-1">
                 <ArrowLeft className="h-4 w-4" />
-                Articles
+                {t('page.title')}
               </Button>
               <ChevronRight className="text-muted-foreground h-4 w-4" />
-              <span className="font-medium">{isEdit ? 'Edit' : 'New'} Article</span>
+              <span className="font-medium">{isEdit ? t('form.breadcrumb.editArticle') : t('form.breadcrumb.newArticle')}</span>
             </div>
 
             {/* Save Button */}
             <Button onClick={saveArticle} disabled={isSaving} className="gap-2">
               {isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-              {isEdit ? 'Update' : 'Create'} Article
+              {isEdit ? t('form.actions.update') : t('form.actions.create')}
             </Button>
           </div>
         </div>
@@ -110,7 +113,7 @@ export default function NewOrEditArticle() {
               <ArticleIcon className="h-6 w-6" />
             </div>
             <div>
-              <h1 className="text-2xl font-bold">{isEdit ? `Edit ${article.articleType === 'MUG' ? 'Mug' : 'Shirt'}` : 'Create New Article'}</h1>
+              <h1 className="text-2xl font-bold">{isEdit ? t('form.header.editTitle', { type: articleTypeLabel }) : t('form.header.createTitle')}</h1>
               {article.name && <p className="text-muted-foreground text-sm">{article.name}</p>}
             </div>
           </div>
@@ -120,31 +123,31 @@ export default function NewOrEditArticle() {
             <TabsList className="grid w-full grid-cols-4 lg:w-auto lg:grid-flow-col">
               <TabsTrigger value="general" className="gap-2">
                 <FileText className="h-4 w-4" />
-                <span className="hidden sm:inline">General</span>
+                <span className="hidden sm:inline">{t('form.tabs.general')}</span>
               </TabsTrigger>
 
               {article.articleType === 'MUG' && (
                 <TabsTrigger value="mug-details" className="gap-2">
                   <Coffee className="h-4 w-4" />
-                  <span className="hidden sm:inline">Mug Details</span>
+                  <span className="hidden sm:inline">{t('form.tabs.mugDetails')}</span>
                 </TabsTrigger>
               )}
 
               {article.articleType === 'SHIRT' && (
                 <TabsTrigger value="shirt-details" className="gap-2">
                   <Shirt className="h-4 w-4" />
-                  <span className="hidden sm:inline">Shirt Details</span>
+                  <span className="hidden sm:inline">{t('form.tabs.shirtDetails')}</span>
                 </TabsTrigger>
               )}
 
               <TabsTrigger value="variants" className="gap-2">
                 <Layers className="h-4 w-4" />
-                <span className="hidden sm:inline">Variants</span>
+                <span className="hidden sm:inline">{t('form.tabs.variants')}</span>
               </TabsTrigger>
 
               <TabsTrigger value="cost-calculation" className="gap-2">
                 <Calculator className="h-4 w-4" />
-                <span className="hidden sm:inline">Price Calculation</span>
+                <span className="hidden sm:inline">{t('form.tabs.priceCalculation')}</span>
               </TabsTrigger>
             </TabsList>
 

--- a/frontend/src/pages/admin/articles/components/GeneralTab.tsx
+++ b/frontend/src/pages/admin/articles/components/GeneralTab.tsx
@@ -11,6 +11,7 @@ import { useArticleFormStore } from '@/stores/admin/articles/useArticleFormStore
 import type { ArticleType } from '@/types/article';
 import type { ArticleCategory, ArticleSubCategory } from '@/types/mug';
 import { Coffee, Shirt } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 interface GeneralTabProps {
   categories: ArticleCategory[];
@@ -20,6 +21,7 @@ interface GeneralTabProps {
 export default function GeneralTab({ categories, subcategories }: GeneralTabProps) {
   const { data: suppliers = [] } = useSuppliers();
   const { article, isEdit, updateArticle, setArticleType, setCategory, setSubcategory } = useArticleFormStore();
+  const { t } = useTranslation('adminArticles');
 
   return (
     <div className="space-y-6">
@@ -27,25 +29,25 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
       {!isEdit && (
         <Card>
           <CardHeader>
-            <CardTitle>Article Type</CardTitle>
-            <CardDescription>Choose the type of product you want to create</CardDescription>
+            <CardTitle>{t('form.general.articleType.title')}</CardTitle>
+            <CardDescription>{t('form.general.articleType.description')}</CardDescription>
           </CardHeader>
           <CardContent>
             <Select value={article.articleType} onValueChange={(value) => setArticleType(value as ArticleType)}>
               <SelectTrigger className="w-full">
-                <SelectValue placeholder="Select article type" />
+                <SelectValue placeholder={t('form.general.articleType.placeholder')} />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="MUG">
                   <div className="flex items-center gap-2">
                     <Coffee className="h-4 w-4" />
-                    Mug
+                    {t('articleTypes.MUG')}
                   </div>
                 </SelectItem>
                 <SelectItem value="SHIRT">
                   <div className="flex items-center gap-2">
                     <Shirt className="h-4 w-4" />
-                    T-Shirt
+                    {t('articleTypes.SHIRT')}
                   </div>
                 </SelectItem>
               </SelectContent>
@@ -59,12 +61,12 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
         <CardHeader>
           <div className="flex items-center justify-between">
             <div>
-              <CardTitle>Basic Information</CardTitle>
-              <CardDescription>Essential details about your article</CardDescription>
+              <CardTitle>{t('form.general.basicInformation.title')}</CardTitle>
+              <CardDescription>{t('form.general.basicInformation.description')}</CardDescription>
             </div>
             <div className="flex items-center gap-2">
               <FieldLabel htmlFor="active" className="text-sm font-normal">
-                Active
+                {t('form.general.basicInformation.fields.active')}
               </FieldLabel>
               <Switch id="active" checked={article.active} onCheckedChange={(checked) => updateArticle('active', checked)} />
             </div>
@@ -73,26 +75,26 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
         <CardContent className="space-y-6">
           <div className="space-y-2">
             <FieldLabel htmlFor="name" required>
-              Article Name
+              {t('form.general.basicInformation.fields.name.label')}
             </FieldLabel>
             <Input
               id="name"
               value={article.name}
               onChange={(e) => updateArticle('name', e.target.value)}
-              placeholder="e.g., Premium Coffee Mug"
+              placeholder={t('form.general.basicInformation.fields.name.placeholder')}
               className="max-w-xl"
             />
           </div>
 
           <div className="space-y-2">
             <FieldLabel htmlFor="descriptionShort" required>
-              Short Description
+              {t('form.general.basicInformation.fields.descriptionShort.label')}
             </FieldLabel>
             <Textarea
               id="descriptionShort"
               value={article.descriptionShort}
               onChange={(e) => updateArticle('descriptionShort', e.target.value)}
-              placeholder="Brief description for product listings"
+              placeholder={t('form.general.basicInformation.fields.descriptionShort.placeholder')}
               rows={2}
               className="max-w-xl"
             />
@@ -100,13 +102,13 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
 
           <div className="space-y-2">
             <FieldLabel htmlFor="descriptionLong" required>
-              Detailed Description
+              {t('form.general.basicInformation.fields.descriptionLong.label')}
             </FieldLabel>
             <Textarea
               id="descriptionLong"
               value={article.descriptionLong}
               onChange={(e) => updateArticle('descriptionLong', e.target.value)}
-              placeholder="Full product description with features and benefits"
+              placeholder={t('form.general.basicInformation.fields.descriptionLong.placeholder')}
               rows={4}
             />
           </div>
@@ -116,18 +118,18 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
       {/* Organization Card */}
       <Card>
         <CardHeader>
-          <CardTitle>Organization</CardTitle>
-          <CardDescription>Categorize and organize your article</CardDescription>
+          <CardTitle>{t('form.general.organization.title')}</CardTitle>
+          <CardDescription>{t('form.general.organization.description')}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
           <div className="grid gap-6 md:grid-cols-2">
             <div className="space-y-2">
               <FieldLabel htmlFor="category" required>
-                Category
+                {t('form.general.organization.fields.category.label')}
               </FieldLabel>
               <Select value={article.categoryId?.toString() || ''} onValueChange={(value) => setCategory(Number(value))}>
                 <SelectTrigger id="category">
-                  <SelectValue placeholder="Select a category" />
+                  <SelectValue placeholder={t('form.general.organization.fields.category.placeholder')} />
                 </SelectTrigger>
                 <SelectContent>
                   {categories.map((category) => (
@@ -141,7 +143,7 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
 
             <div className="space-y-2">
               <FieldLabel htmlFor="subcategory" optional>
-                Subcategory
+                {t('form.general.organization.fields.subcategory.label')}
               </FieldLabel>
               <Select
                 value={article.subcategoryId?.toString() || ''}
@@ -149,7 +151,13 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
                 disabled={!article.categoryId}
               >
                 <SelectTrigger id="subcategory">
-                  <SelectValue placeholder={article.categoryId ? 'Select a subcategory' : 'Select category first'} />
+                  <SelectValue
+                    placeholder={
+                      article.categoryId
+                        ? t('form.general.organization.fields.subcategory.placeholder')
+                        : t('form.general.organization.fields.subcategory.disabledPlaceholder')
+                    }
+                  />
                 </SelectTrigger>
                 <SelectContent>
                   {subcategories.map((subcategory) => (
@@ -165,17 +173,17 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
           <div className="grid gap-6 md:grid-cols-2">
             <div className="space-y-2">
               <FieldLabel htmlFor="supplier" optional>
-                Supplier
+                {t('form.general.organization.fields.supplier.label')}
               </FieldLabel>
               <Select
                 value={article.supplierId?.toString() || 'none'}
                 onValueChange={(value) => updateArticle('supplierId', value === 'none' ? undefined : Number(value))}
               >
                 <SelectTrigger id="supplier">
-                  <SelectValue placeholder="Select a supplier (optional)" />
+                  <SelectValue placeholder={t('form.general.organization.fields.supplier.placeholder')} />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="none">No supplier</SelectItem>
+                  <SelectItem value="none">{t('form.general.organization.fields.supplier.none')}</SelectItem>
                   {suppliers.map((supplier) => (
                     <SelectItem key={supplier.id} value={supplier.id.toString()}>
                       {supplier.name || `${supplier.firstName} ${supplier.lastName}`}
@@ -186,7 +194,7 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
             </div>
 
             <div className="space-y-2">
-              <FieldLabel htmlFor="articleNumber">Article Number</FieldLabel>
+              <FieldLabel htmlFor="articleNumber">{t('form.general.organization.fields.articleNumber.label')}</FieldLabel>
               <InputWithCopy
                 id="articleNumber"
                 value={generateArticleNumber(article.categoryId, article.subcategoryId, article.id) || getArticleNumberPlaceholder()}
@@ -200,25 +208,25 @@ export default function GeneralTab({ categories, subcategories }: GeneralTabProp
             <div className="grid gap-6 md:grid-cols-2">
               <div className="space-y-2">
                 <FieldLabel htmlFor="supplierArticleName" optional>
-                  Supplier Article Name
+                  {t('form.general.organization.fields.supplierArticleName.label')}
                 </FieldLabel>
                 <Input
                   id="supplierArticleName"
                   value={article.supplierArticleName || ''}
                   onChange={(e) => updateArticle('supplierArticleName', e.target.value || undefined)}
-                  placeholder="e.g., Premium Ceramic Mug"
+                  placeholder={t('form.general.organization.fields.supplierArticleName.placeholder')}
                 />
               </div>
 
               <div className="space-y-2">
                 <FieldLabel htmlFor="supplierArticleNumber" optional>
-                  Supplier Article Number
+                  {t('form.general.organization.fields.supplierArticleNumber.label')}
                 </FieldLabel>
                 <Input
                   id="supplierArticleNumber"
                   value={article.supplierArticleNumber || ''}
                   onChange={(e) => updateArticle('supplierArticleNumber', e.target.value || undefined)}
-                  placeholder="e.g., SKU-12345"
+                  placeholder={t('form.general.organization.fields.supplierArticleNumber.placeholder')}
                 />
               </div>
             </div>

--- a/frontend/src/pages/admin/articles/components/PriceCalculationTab.tsx
+++ b/frontend/src/pages/admin/articles/components/PriceCalculationTab.tsx
@@ -6,9 +6,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useVats } from '@/hooks/queries/useVat';
 import { useArticleFormStore } from '@/stores/admin/articles/useArticleFormStore';
 import { useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 export default function PriceCalculationTab() {
   const { data: vats = [] } = useVats();
+  const { t } = useTranslation('adminArticles');
 
   const {
     costCalculation,
@@ -84,16 +86,16 @@ export default function PriceCalculationTab() {
       {/* Purchase Section */}
       <Card>
         <CardHeader>
-          <CardTitle>Purchase</CardTitle>
-          <CardDescription>Purchase price and price calculations</CardDescription>
+          <CardTitle>{t('form.price.purchase.title')}</CardTitle>
+          <CardDescription>{t('form.price.purchase.description')}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Tax Rate */}
           <div className="grid grid-cols-4 items-center gap-4">
-            <FieldLabel optional>Tax Rate</FieldLabel>
+            <FieldLabel optional>{t('form.price.common.vatLabel')}</FieldLabel>
             <Select value={costCalculation.purchaseVatRateId?.toString() || ''} onValueChange={handlePurchaseVatRateChange}>
               <SelectTrigger>
-                <SelectValue placeholder="Select VAT rate" />
+                <SelectValue placeholder={t('form.price.common.vatPlaceholder')} />
               </SelectTrigger>
               <SelectContent>
                 {vats.map((vat) => (
@@ -103,7 +105,7 @@ export default function PriceCalculationTab() {
                 ))}
               </SelectContent>
             </Select>
-            <div className="text-muted-foreground col-span-2 text-sm">(from article or service group)</div>
+            <div className="text-muted-foreground col-span-2 text-sm">{t('form.price.common.vatHelper')}</div>
           </div>
 
           {/* Calculation Mode */}
@@ -117,7 +119,7 @@ export default function PriceCalculationTab() {
                 onChange={() => setPurchaseCalculationMode('NET')}
                 className="h-4 w-4"
               />
-              <span>Net</span>
+              <span>{t('form.common.net')}</span>
             </label>
             <label className="flex items-center space-x-2">
               <input
@@ -128,21 +130,21 @@ export default function PriceCalculationTab() {
                 onChange={() => setPurchaseCalculationMode('GROSS')}
                 className="h-4 w-4"
               />
-              <span>Gross</span>
+              <span>{t('form.common.gross')}</span>
             </label>
           </div>
 
           {/* Headers */}
           <div className="text-muted-foreground grid grid-cols-4 gap-4 text-sm font-medium">
             <div></div>
-            <div className="text-center">Net</div>
-            <div className="text-center">Tax</div>
-            <div className="text-center">Gross</div>
+            <div className="text-center">{t('form.common.net')}</div>
+            <div className="text-center">{t('form.common.tax')}</div>
+            <div className="text-center">{t('form.common.gross')}</div>
           </div>
 
           {/* Purchase Price */}
           <div className="grid grid-cols-4 items-center gap-4">
-            <FieldLabel optional>Purchase Price</FieldLabel>
+            <FieldLabel optional>{t('form.price.purchase.fields.price')}</FieldLabel>
             <CurrencyInput
               value={costCalculation.purchasePriceNet}
               onChange={(value) => updatePurchasePrice('net', value)}
@@ -171,7 +173,7 @@ export default function PriceCalculationTab() {
                 className="h-4 w-4"
               />
               <FieldLabel htmlFor="purchaseCostRadio" optional>
-                Purchase Cost
+                {t('form.price.purchase.fields.cost')}
               </FieldLabel>
             </div>
             <CurrencyInput
@@ -202,7 +204,7 @@ export default function PriceCalculationTab() {
                 className="h-4 w-4"
               />
               <FieldLabel htmlFor="purchaseCostPercentRadio" optional>
-                Purchase Cost %
+                {t('form.price.purchase.fields.costPercent')}
               </FieldLabel>
             </div>
             <CurrencyInput
@@ -221,7 +223,7 @@ export default function PriceCalculationTab() {
 
           {/* Purchase Total */}
           <div className="grid grid-cols-4 items-center gap-4 font-semibold">
-            <FieldLabel>Purchase Total</FieldLabel>
+            <FieldLabel>{t('form.price.purchase.fields.total')}</FieldLabel>
             <CurrencyInput value={costCalculation.purchaseTotalNet} onChange={() => {}} disabled />
             <CurrencyInput value={costCalculation.purchaseTotalTax} onChange={() => {}} disabled />
             <CurrencyInput value={costCalculation.purchaseTotalGross} onChange={() => {}} disabled />
@@ -230,15 +232,15 @@ export default function PriceCalculationTab() {
           {/* Price corresponds selection */}
           <div className="flex flex-wrap items-center gap-2 pt-2">
             <FieldLabel htmlFor="purchasePriceCorresponds" className="text-sm font-normal" optional>
-              Price corresponds to
+              {t('form.price.common.priceCorresponds')}
             </FieldLabel>
             <Select value={costCalculation.purchasePriceCorresponds} onValueChange={handlePurchasePriceCorrespondsChange}>
               <SelectTrigger id="purchasePriceCorresponds" className="w-32">
-                <SelectValue placeholder="Select" />
+                <SelectValue placeholder={t('form.common.select')} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="NET">Net</SelectItem>
-                <SelectItem value="GROSS">Gross</SelectItem>
+                <SelectItem value="NET">{t('form.common.net')}</SelectItem>
+                <SelectItem value="GROSS">{t('form.common.gross')}</SelectItem>
               </SelectContent>
             </Select>
             <Input
@@ -246,9 +248,9 @@ export default function PriceCalculationTab() {
               value={costCalculation.purchasePriceUnit}
               onChange={(e) => updateCostField('purchasePriceUnit', e.target.value)}
               className="w-32"
-              placeholder="1.00"
+              placeholder={t('form.common.unitPlaceholder')}
             />
-            <span className="text-muted-foreground text-sm">Quantity unit(s) or packaging</span>
+            <span className="text-muted-foreground text-sm">{t('form.price.common.quantityHelper')}</span>
           </div>
         </CardContent>
       </Card>
@@ -256,16 +258,16 @@ export default function PriceCalculationTab() {
       {/* Sales Section */}
       <Card>
         <CardHeader>
-          <CardTitle>Sales</CardTitle>
-          <CardDescription>Sales price and margin calculations</CardDescription>
+          <CardTitle>{t('form.price.sales.title')}</CardTitle>
+          <CardDescription>{t('form.price.sales.description')}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Tax Rate */}
           <div className="grid grid-cols-4 items-center gap-4">
-            <FieldLabel optional>Tax Rate</FieldLabel>
+            <FieldLabel optional>{t('form.price.common.vatLabel')}</FieldLabel>
             <Select value={costCalculation.salesVatRateId?.toString() || ''} onValueChange={handleSalesVatRateChange}>
               <SelectTrigger>
-                <SelectValue placeholder="Select VAT rate" />
+                <SelectValue placeholder={t('form.price.common.vatPlaceholder')} />
               </SelectTrigger>
               <SelectContent>
                 {vats.map((vat) => (
@@ -275,7 +277,7 @@ export default function PriceCalculationTab() {
                 ))}
               </SelectContent>
             </Select>
-            <div className="text-muted-foreground col-span-2 text-sm">(from article or service group)</div>
+            <div className="text-muted-foreground col-span-2 text-sm">{t('form.price.common.vatHelper')}</div>
           </div>
 
           {/* Calculation Mode */}
@@ -289,7 +291,7 @@ export default function PriceCalculationTab() {
                 onChange={() => setSalesCalculationMode('NET')}
                 className="h-4 w-4"
               />
-              <span>Net</span>
+              <span>{t('form.common.net')}</span>
             </label>
             <label className="flex items-center space-x-2">
               <input
@@ -300,16 +302,16 @@ export default function PriceCalculationTab() {
                 onChange={() => setSalesCalculationMode('GROSS')}
                 className="h-4 w-4"
               />
-              <span>Gross</span>
+              <span>{t('form.common.gross')}</span>
             </label>
           </div>
 
           {/* Headers */}
           <div className="text-muted-foreground grid grid-cols-4 gap-4 text-sm font-medium">
             <div></div>
-            <div className="text-center">Net</div>
-            <div className="text-center">Tax</div>
-            <div className="text-center">Gross</div>
+            <div className="text-center">{t('form.common.net')}</div>
+            <div className="text-center">{t('form.common.tax')}</div>
+            <div className="text-center">{t('form.common.gross')}</div>
           </div>
 
           {/* Margin */}
@@ -325,7 +327,7 @@ export default function PriceCalculationTab() {
                 className="h-4 w-4"
               />
               <FieldLabel htmlFor="salesMarginRadio" optional>
-                Margin
+                {t('form.price.sales.fields.margin')}
               </FieldLabel>
             </div>
             <CurrencyInput
@@ -354,7 +356,7 @@ export default function PriceCalculationTab() {
                 className="h-4 w-4"
               />
               <FieldLabel htmlFor="salesMarginPercentRadio" optional>
-                Margin %
+                {t('form.price.sales.fields.marginPercent')}
               </FieldLabel>
             </div>
             <CurrencyInput
@@ -382,7 +384,7 @@ export default function PriceCalculationTab() {
                 onChange={() => updateCostField('salesActiveRow', 'TOTAL')}
                 className="h-4 w-4"
               />
-              <FieldLabel htmlFor="salesTotalRadio">Sales Total</FieldLabel>
+              <FieldLabel htmlFor="salesTotalRadio">{t('form.price.sales.fields.total')}</FieldLabel>
             </div>
             <CurrencyInput
               value={costCalculation.salesTotalNet}
@@ -400,15 +402,15 @@ export default function PriceCalculationTab() {
           {/* Price corresponds selection */}
           <div className="flex flex-wrap items-center gap-2 pt-2">
             <FieldLabel htmlFor="salesPriceCorresponds" className="text-sm font-normal" optional>
-              Price corresponds to
+              {t('form.price.common.priceCorresponds')}
             </FieldLabel>
             <Select value={costCalculation.salesPriceCorresponds} onValueChange={handleSalesPriceCorrespondsChange}>
               <SelectTrigger id="salesPriceCorresponds" className="w-32">
-                <SelectValue placeholder="Select" />
+                <SelectValue placeholder={t('form.common.select')} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="NET">Net</SelectItem>
-                <SelectItem value="GROSS">Gross</SelectItem>
+                <SelectItem value="NET">{t('form.common.net')}</SelectItem>
+                <SelectItem value="GROSS">{t('form.common.gross')}</SelectItem>
               </SelectContent>
             </Select>
             <Input
@@ -416,9 +418,9 @@ export default function PriceCalculationTab() {
               value={costCalculation.salesPriceUnit}
               onChange={(e) => updateCostField('salesPriceUnit', e.target.value)}
               className="w-32"
-              placeholder="1.00"
+              placeholder={t('form.common.unitPlaceholder')}
             />
-            <span className="text-muted-foreground text-sm">Quantity unit(s) or packaging</span>
+            <span className="text-muted-foreground text-sm">{t('form.price.common.quantityHelper')}</span>
           </div>
         </CardContent>
       </Card>

--- a/frontend/src/pages/admin/articles/tabs/MugDetailsTab.tsx
+++ b/frontend/src/pages/admin/articles/tabs/MugDetailsTab.tsx
@@ -4,10 +4,12 @@ import { Input } from '@/components/ui/Input';
 import { Switch } from '@/components/ui/Switch';
 import { useArticleFormStore } from '@/stores/admin/articles/useArticleFormStore';
 import type { CreateMugDetailsRequest } from '@/types/article';
+import { useTranslation } from 'react-i18next';
 
 export default function MugDetailsTab() {
   const { article, updateMugDetails } = useArticleFormStore();
   const mugDetails = article.mugDetails;
+  const { t } = useTranslation('adminArticles');
 
   const handleChange = (field: keyof CreateMugDetailsRequest, value: string | number | boolean | undefined) => {
     // Ensure numeric fields are integers
@@ -41,17 +43,17 @@ export default function MugDetailsTab() {
     const docMargin = mugDetails?.documentFormatMarginBottomMm;
 
     if (docWidth !== undefined) {
-      if (docWidth <= 0) errors.push('Document width must be positive');
-      if (docWidth <= printWidth) errors.push('Document width should be greater than print template width');
+      if (docWidth <= 0) errors.push(t('form.mugDetails.validation.documentWidthPositive'));
+      if (docWidth <= printWidth) errors.push(t('form.mugDetails.validation.documentWidthLarger'));
     }
 
     if (docHeight !== undefined) {
-      if (docHeight <= 0) errors.push('Document height must be positive');
-      if (docHeight <= printHeight) errors.push('Document height should be greater than print template height');
+      if (docHeight <= 0) errors.push(t('form.mugDetails.validation.documentHeightPositive'));
+      if (docHeight <= printHeight) errors.push(t('form.mugDetails.validation.documentHeightLarger'));
     }
 
     if (docMargin !== undefined && (docMargin < 0 || docMargin > 100)) {
-      errors.push('Bottom margin should be between 0-100mm');
+      errors.push(t('form.mugDetails.validation.documentMarginRange'));
     }
 
     return errors;
@@ -62,21 +64,21 @@ export default function MugDetailsTab() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Mug Specifications</CardTitle>
-        <CardDescription>Physical dimensions and properties</CardDescription>
+        <CardTitle>{t('form.mugDetails.title')}</CardTitle>
+        <CardDescription>{t('form.mugDetails.description')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2">
             <FieldLabel htmlFor="heightMm" required>
-              Height (mm)
+              {t('form.mugDetails.fields.height.label', { unit: 'mm' })}
             </FieldLabel>
             <Input
               id="heightMm"
               type="number"
               value={mugDetails?.heightMm || 0}
               onChange={(e) => handleChange('heightMm', Number(e.target.value))}
-              placeholder="95"
+              placeholder={t('form.mugDetails.fields.height.placeholder')}
               min="0"
               step="1"
             />
@@ -84,14 +86,14 @@ export default function MugDetailsTab() {
 
           <div className="space-y-2">
             <FieldLabel htmlFor="diameterMm" required>
-              Diameter (mm)
+              {t('form.mugDetails.fields.diameter.label', { unit: 'mm' })}
             </FieldLabel>
             <Input
               id="diameterMm"
               type="number"
               value={mugDetails?.diameterMm || 0}
               onChange={(e) => handleChange('diameterMm', Number(e.target.value))}
-              placeholder="82"
+              placeholder={t('form.mugDetails.fields.diameter.placeholder')}
               min="0"
               step="1"
             />
@@ -100,13 +102,13 @@ export default function MugDetailsTab() {
 
         <div className="space-y-2">
           <FieldLabel htmlFor="fillingQuantity" optional>
-            Filling Quantity
+            {t('form.mugDetails.fields.fillingQuantity.label')}
           </FieldLabel>
           <Input
             id="fillingQuantity"
             value={mugDetails?.fillingQuantity || ''}
             onChange={(e) => handleChange('fillingQuantity', e.target.value)}
-            placeholder="250ml"
+            placeholder={t('form.mugDetails.fields.fillingQuantity.placeholder')}
           />
         </div>
 
@@ -116,14 +118,14 @@ export default function MugDetailsTab() {
             checked={mugDetails?.dishwasherSafe ?? true}
             onCheckedChange={(checked) => handleChange('dishwasherSafe', checked)}
           />
-          <FieldLabel htmlFor="dishwasherSafe">Dishwasher Safe</FieldLabel>
+          <FieldLabel htmlFor="dishwasherSafe">{t('form.mugDetails.fields.dishwasherSafe')}</FieldLabel>
         </div>
 
         {/* Document Format Section */}
         <div className="border-t pt-6">
           <div className="mb-4">
-            <h3 className="text-lg font-medium">Document Format</h3>
-            <p className="mt-1 text-sm text-gray-600">Optional dimensions for PDF generation.</p>
+            <h3 className="text-lg font-medium">{t('form.mugDetails.documentFormat.title')}</h3>
+            <p className="mt-1 text-sm text-gray-600">{t('form.mugDetails.documentFormat.description')}</p>
           </div>
 
           {validationErrors.length > 0 && (
@@ -141,14 +143,14 @@ export default function MugDetailsTab() {
           <div className="mb-4 grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <FieldLabel htmlFor="printTemplateWidthMm" required>
-                Print Template Width (mm)
+                {t('form.mugDetails.fields.printTemplateWidth.label', { unit: 'mm' })}
               </FieldLabel>
               <Input
                 id="printTemplateWidthMm"
                 type="number"
                 value={mugDetails?.printTemplateWidthMm || 0}
                 onChange={(e) => handleChange('printTemplateWidthMm', Number(e.target.value))}
-                placeholder="200"
+                placeholder={t('form.mugDetails.fields.printTemplateWidth.placeholder')}
                 min="0"
                 step="1"
               />
@@ -156,14 +158,14 @@ export default function MugDetailsTab() {
 
             <div className="space-y-2">
               <FieldLabel htmlFor="printTemplateHeightMm" required>
-                Print Template Height (mm)
+                {t('form.mugDetails.fields.printTemplateHeight.label', { unit: 'mm' })}
               </FieldLabel>
               <Input
                 id="printTemplateHeightMm"
                 type="number"
                 value={mugDetails?.printTemplateHeightMm || 0}
                 onChange={(e) => handleChange('printTemplateHeightMm', Number(e.target.value))}
-                placeholder="80"
+                placeholder={t('form.mugDetails.fields.printTemplateHeight.placeholder')}
                 min="0"
                 step="1"
               />
@@ -173,7 +175,7 @@ export default function MugDetailsTab() {
           <div className="mb-4 grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <FieldLabel htmlFor="documentFormatWidthMm" required>
-                Document Width (mm)
+                {t('form.mugDetails.fields.documentWidth.label', { unit: 'mm' })}
               </FieldLabel>
               <Input
                 id="documentFormatWidthMm"
@@ -183,7 +185,7 @@ export default function MugDetailsTab() {
                   const value = e.target.value;
                   handleChange('documentFormatWidthMm', value ? Number(value) : undefined);
                 }}
-                placeholder="e.g. 250"
+                placeholder={t('form.mugDetails.fields.documentWidth.placeholder')}
                 min="1"
                 step="1"
               />
@@ -191,7 +193,7 @@ export default function MugDetailsTab() {
 
             <div className="space-y-2">
               <FieldLabel htmlFor="documentFormatHeightMm" required>
-                Document Height (mm)
+                {t('form.mugDetails.fields.documentHeight.label', { unit: 'mm' })}
               </FieldLabel>
               <Input
                 id="documentFormatHeightMm"
@@ -201,7 +203,7 @@ export default function MugDetailsTab() {
                   const value = e.target.value;
                   handleChange('documentFormatHeightMm', value ? Number(value) : undefined);
                 }}
-                placeholder="e.g. 120"
+                placeholder={t('form.mugDetails.fields.documentHeight.placeholder')}
                 min="1"
                 step="1"
               />
@@ -210,7 +212,7 @@ export default function MugDetailsTab() {
 
           <div className="space-y-2">
             <FieldLabel htmlFor="documentFormatMarginBottomMm" required>
-              Bottom Margin (mm)
+              {t('form.mugDetails.fields.documentMargin.label', { unit: 'mm' })}
             </FieldLabel>
             <Input
               id="documentFormatMarginBottomMm"
@@ -220,7 +222,7 @@ export default function MugDetailsTab() {
                 const value = e.target.value;
                 handleChange('documentFormatMarginBottomMm', value ? Number(value) : undefined);
               }}
-              placeholder="e.g. 10"
+              placeholder={t('form.mugDetails.fields.documentMargin.placeholder')}
               min="0"
               max="100"
               step="1"

--- a/frontend/src/pages/admin/articles/tabs/MugVariantsTab.tsx
+++ b/frontend/src/pages/admin/articles/tabs/MugVariantsTab.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils';
 import type { ArticleMugVariant, CreateArticleMugVariantRequest } from '@/types/article';
 import { Copy, Edit, Image as ImageIcon, Plus, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -33,19 +34,20 @@ function VariantTable<T extends ArticleMugVariant | CreateArticleMugVariantReque
   onDelete,
   isTemporary = false,
 }: VariantTableProps<T>) {
+  const { t } = useTranslation('adminArticles');
   return (
     <div className="rounded-md border">
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Article Variant Number</TableHead>
-            <TableHead>Inside Color</TableHead>
-            <TableHead>Outside Color</TableHead>
-            <TableHead>Default</TableHead>
-            <TableHead>Active</TableHead>
-            <TableHead>Example Image</TableHead>
-            <TableHead className="text-right">Actions</TableHead>
+            <TableHead>{t('form.mugVariants.table.name')}</TableHead>
+            <TableHead>{t('form.mugVariants.table.articleVariantNumber')}</TableHead>
+            <TableHead>{t('form.mugVariants.table.insideColor')}</TableHead>
+            <TableHead>{t('form.mugVariants.table.outsideColor')}</TableHead>
+            <TableHead>{t('form.common.default')}</TableHead>
+            <TableHead>{t('form.common.active')}</TableHead>
+            <TableHead>{t('form.mugVariants.table.exampleImage')}</TableHead>
+            <TableHead className="text-right">{t('form.common.actions')}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -55,7 +57,9 @@ function VariantTable<T extends ArticleMugVariant | CreateArticleMugVariantReque
                 <div className="flex items-center gap-2">
                   {variant.name}
                   {!isActive(variant) && (
-                    <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">Inactive</span>
+                    <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600">
+                      {t('form.common.inactive')}
+                    </span>
                   )}
                 </div>
               </TableCell>
@@ -68,21 +72,27 @@ function VariantTable<T extends ArticleMugVariant | CreateArticleMugVariantReque
               </TableCell>
               <TableCell>
                 {variant.isDefault && (
-                  <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-700">Default</span>
+                  <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-700">
+                    {t('form.common.default')}
+                  </span>
                 )}
               </TableCell>
               <TableCell>
                 {isActive(variant) ? (
-                  <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-700">Active</span>
+                  <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-700">
+                    {t('form.common.active')}
+                  </span>
                 ) : (
-                  <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-1 text-xs font-medium text-red-700">Inactive</span>
+                  <span className="inline-flex items-center rounded-full bg-red-100 px-2 py-1 text-xs font-medium text-red-700">
+                    {t('form.common.inactive')}
+                  </span>
                 )}
               </TableCell>
               <TableCell>
                 {!isTemporary && (variant as ArticleMugVariant).exampleImageUrl ? (
                   <img
                     src={(variant as ArticleMugVariant).exampleImageUrl!}
-                    alt={`${variant.name} example`}
+                    alt={t('form.mugVariants.imageAlt', { name: variant.name })}
                     className="h-10 w-10 rounded border object-cover"
                   />
                 ) : (
@@ -138,6 +148,7 @@ export default function MugVariantsTab({
   const [variants, setVariants] = useState<ArticleMugVariant[]>(initialVariants);
   const [dialogState, setDialogState] = useState<DialogState>({ type: 'closed' });
   const [deleteState, setDeleteState] = useState<DeleteState>({ type: 'none' });
+  const { t } = useTranslation('adminArticles');
 
   // Sync local state with prop changes (important for when variants are copied or refetched)
   useEffect(() => {
@@ -192,17 +203,17 @@ export default function MugVariantsTab({
     switch (deleteState.type) {
       case 'temporary':
         onDeleteTemporaryVariant?.(deleteState.index);
-        toast.success('Variant removed');
+        toast.success(t('form.mugVariants.toasts.removed'));
         break;
 
       case 'saved':
         try {
           await articlesApi.deleteMugVariant(deleteState.id);
           setVariants((prev) => prev.filter((v) => v.id !== deleteState.id));
-          toast.success('Variant deleted successfully');
+          toast.success(t('form.mugVariants.toasts.deleted'));
         } catch (error) {
           console.error('Error deleting variant:', error);
-          toast.error('Failed to delete variant');
+          toast.error(t('form.mugVariants.toasts.deleteError'));
         }
         break;
     }
@@ -213,7 +224,7 @@ export default function MugVariantsTab({
 
   const handleCopyVariants = () => {
     if (!articleId) {
-      toast.error('Please save the article first before copying variants');
+      toast.error(t('form.mugVariants.toasts.saveBeforeCopy'));
       return;
     }
     navigate(`/admin/articles/${articleId}/copy-variants`);
@@ -222,14 +233,12 @@ export default function MugVariantsTab({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Mug Variants</CardTitle>
-        <CardDescription>Add different color combinations for this mug. Each variant can have different inside and outside colors.</CardDescription>
+        <CardTitle>{t('form.mugVariants.title')}</CardTitle>
+        <CardDescription>{t('form.mugVariants.description')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {!articleId && temporaryVariants.length > 0 && (
-          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800">
-            These variants will be saved when you save the article.
-          </div>
+          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800">{t('form.mugVariants.info.unsavedNotice')}</div>
         )}
 
         <MugVariantDialog
@@ -250,12 +259,12 @@ export default function MugVariantsTab({
           {articleId && (
             <Button onClick={handleCopyVariants} variant="outline" className="min-w-[140px]">
               <Copy className="mr-2 h-4 w-4" />
-              Copy Variants
+              {t('form.mugVariants.actions.copy')}
             </Button>
           )}
           <Button onClick={handleAddVariant} className="min-w-[140px]">
             <Plus className="mr-2 h-4 w-4" />
-            Add Variant
+            {t('form.mugVariants.actions.add')}
           </Button>
         </div>
 
@@ -279,9 +288,9 @@ export default function MugVariantsTab({
         isOpen={deleteState.type !== 'none'}
         onConfirm={confirmDelete}
         onCancel={cancelDelete}
-        title="Delete Mug Variant"
-        description="Are you sure you want to delete this mug variant? This action cannot be undone."
-        confirmText="Delete Variant"
+        title={t('form.mugVariants.confirmation.title')}
+        description={t('form.mugVariants.confirmation.description')}
+        confirmText={t('form.mugVariants.confirmation.confirm')}
       />
     </Card>
   );

--- a/frontend/src/pages/admin/articles/tabs/ShirtDetailsTab.tsx
+++ b/frontend/src/pages/admin/articles/tabs/ShirtDetailsTab.tsx
@@ -6,6 +6,7 @@ import { Label } from '@/components/ui/Label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
 import type { CreateShirtDetailsRequest, FitType } from '@/types/article';
+import { useTranslation } from 'react-i18next';
 
 interface ShirtDetailsTabProps {
   shirtDetails?: Partial<CreateShirtDetailsRequest>;
@@ -21,6 +22,7 @@ export default function ShirtDetailsTab({ shirtDetails, onChange }: ShirtDetails
     fitType: shirtDetails?.fitType || 'REGULAR',
     availableSizes: shirtDetails?.availableSizes || [],
   };
+  const { t } = useTranslation('adminArticles');
 
   const handleChange = (field: keyof CreateShirtDetailsRequest, value: string | string[] | FitType) => {
     onChange({ ...details, [field]: value });
@@ -34,48 +36,53 @@ export default function ShirtDetailsTab({ shirtDetails, onChange }: ShirtDetails
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Shirt Details</CardTitle>
-        <CardDescription>Material and sizing information</CardDescription>
+        <CardTitle>{t('form.shirtDetails.title')}</CardTitle>
+        <CardDescription>{t('form.shirtDetails.description')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="space-y-2">
           <FieldLabel htmlFor="material" required>
-            Material
+            {t('form.shirtDetails.fields.material.label')}
           </FieldLabel>
-          <Input id="material" value={details.material} onChange={(e) => handleChange('material', e.target.value)} placeholder="100% Cotton" />
+          <Input
+            id="material"
+            value={details.material}
+            onChange={(e) => handleChange('material', e.target.value)}
+            placeholder={t('form.shirtDetails.fields.material.placeholder')}
+          />
         </div>
 
         <div className="space-y-2">
           <FieldLabel htmlFor="fitType" required>
-            Fit Type
+            {t('form.shirtDetails.fields.fitType.label')}
           </FieldLabel>
           <Select value={details.fitType} onValueChange={(value) => handleChange('fitType', value as FitType)}>
             <SelectTrigger id="fitType">
-              <SelectValue placeholder="Select fit type" />
+              <SelectValue placeholder={t('form.shirtDetails.fields.fitType.placeholder')} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="REGULAR">Regular</SelectItem>
-              <SelectItem value="SLIM">Slim</SelectItem>
-              <SelectItem value="LOOSE">Loose</SelectItem>
+              <SelectItem value="REGULAR">{t('form.shirtDetails.fields.fitType.options.regular')}</SelectItem>
+              <SelectItem value="SLIM">{t('form.shirtDetails.fields.fitType.options.slim')}</SelectItem>
+              <SelectItem value="LOOSE">{t('form.shirtDetails.fields.fitType.options.loose')}</SelectItem>
             </SelectContent>
           </Select>
         </div>
 
         <div className="space-y-2">
           <FieldLabel htmlFor="careInstructions" optional>
-            Care Instructions
+            {t('form.shirtDetails.fields.careInstructions.label')}
           </FieldLabel>
           <Textarea
             id="careInstructions"
             value={details.careInstructions}
             onChange={(e) => handleChange('careInstructions', e.target.value)}
-            placeholder="Machine wash cold, tumble dry low"
+            placeholder={t('form.shirtDetails.fields.careInstructions.placeholder')}
             rows={3}
           />
         </div>
 
         <div className="space-y-2">
-          <FieldLabel required>Available Sizes</FieldLabel>
+          <FieldLabel required>{t('form.shirtDetails.fields.availableSizes.label')}</FieldLabel>
           <div className="grid grid-cols-4 gap-3">
             {AVAILABLE_SIZES.map((size) => (
               <div key={size} className="flex items-center space-x-2">

--- a/frontend/src/pages/admin/articles/tabs/ShirtVariantsTab.tsx
+++ b/frontend/src/pages/admin/articles/tabs/ShirtVariantsTab.tsx
@@ -8,6 +8,7 @@ import { articlesApi } from '@/lib/api';
 import type { ArticleShirtVariant, CreateArticleShirtVariantRequest } from '@/types/article';
 import { Plus, Trash2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 
 interface ShirtVariantsTabProps {
@@ -34,6 +35,7 @@ export default function ShirtVariantsTab({
     size: 'M',
     exampleImageFilename: '',
   });
+  const { t } = useTranslation('adminArticles');
 
   // Sync local state with prop changes (important for when variants are copied or refetched)
   useEffect(() => {
@@ -42,7 +44,7 @@ export default function ShirtVariantsTab({
 
   const handleAddVariant = async () => {
     if (!newVariant.color) {
-      toast.error('Please enter a color');
+      toast.error(t('form.shirtVariants.toasts.colorRequired'));
       return;
     }
 
@@ -52,7 +54,7 @@ export default function ShirtVariantsTab({
       : temporaryVariants.some((v) => v.color === newVariant.color && v.size === newVariant.size);
 
     if (isDuplicate) {
-      toast.error('This color and size combination already exists');
+      toast.error(t('form.shirtVariants.toasts.duplicate'));
       return;
     }
 
@@ -65,7 +67,7 @@ export default function ShirtVariantsTab({
           size: 'M',
           exampleImageFilename: '',
         });
-        toast.success('Variant added (will be saved with article)');
+        toast.success(t('form.shirtVariants.toasts.addedTemporary'));
       }
       return;
     }
@@ -79,10 +81,10 @@ export default function ShirtVariantsTab({
         size: 'M',
         exampleImageFilename: '',
       });
-      toast.success('Variant added successfully');
+      toast.success(t('form.shirtVariants.toasts.added'));
     } catch (error) {
       console.error('Error adding variant:', error);
-      toast.error('Failed to add variant');
+      toast.error(t('form.shirtVariants.toasts.addError'));
     }
   };
 
@@ -90,45 +92,47 @@ export default function ShirtVariantsTab({
     try {
       await articlesApi.deleteShirtVariant(variantId);
       setVariants(variants.filter((v) => v.id !== variantId));
-      toast.success('Variant deleted successfully');
+      toast.success(t('form.shirtVariants.toasts.deleted'));
     } catch (error) {
       console.error('Error deleting variant:', error);
-      toast.error('Failed to delete variant');
+      toast.error(t('form.shirtVariants.toasts.deleteError'));
     }
   };
 
   const handleDeleteTemporaryVariant = (index: number) => {
     if (onDeleteTemporaryVariant) {
       onDeleteTemporaryVariant(index);
-      toast.success('Variant removed');
+      toast.success(t('form.shirtVariants.toasts.removed'));
     }
   };
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Shirt Variants</CardTitle>
-        <CardDescription>Add color and size combinations for this shirt. Each combination represents a unique product variant.</CardDescription>
+        <CardTitle>{t('form.shirtVariants.title')}</CardTitle>
+        <CardDescription>{t('form.shirtVariants.description')}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {!articleId && temporaryVariants.length > 0 && (
-          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800">
-            These variants will be saved when you save the article.
-          </div>
+          <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800">{t('form.shirtVariants.info.unsavedNotice')}</div>
         )}
 
         <div className="space-y-4">
           <div className="grid grid-cols-5 gap-4">
             <div className="space-y-2">
-              <Label>Color</Label>
-              <Input value={newVariant.color} onChange={(e) => setNewVariant({ ...newVariant, color: e.target.value })} placeholder="e.g., Black" />
+              <Label>{t('form.shirtVariants.fields.color.label')}</Label>
+              <Input
+                value={newVariant.color}
+                onChange={(e) => setNewVariant({ ...newVariant, color: e.target.value })}
+                placeholder={t('form.shirtVariants.fields.color.placeholder')}
+              />
             </div>
 
             <div className="space-y-2">
-              <Label>Size</Label>
+              <Label>{t('form.shirtVariants.fields.size.label')}</Label>
               <Select value={newVariant.size} onValueChange={(value) => setNewVariant({ ...newVariant, size: value })}>
                 <SelectTrigger>
-                  <SelectValue />
+                  <SelectValue placeholder={t('form.common.select')} />
                 </SelectTrigger>
                 <SelectContent>
                   {SHIRT_SIZES.map((size) => (
@@ -141,18 +145,18 @@ export default function ShirtVariantsTab({
             </div>
 
             <div className="space-y-2">
-              <Label>Example Image</Label>
+              <Label>{t('form.shirtVariants.fields.exampleImage.label')}</Label>
               <Input
                 value={newVariant.exampleImageFilename}
                 onChange={(e) => setNewVariant({ ...newVariant, exampleImageFilename: e.target.value })}
-                placeholder="image.jpg"
+                placeholder={t('form.shirtVariants.fields.exampleImage.placeholder')}
               />
             </div>
 
             <div className="flex items-end">
               <Button onClick={handleAddVariant} className="w-full">
                 <Plus className="mr-2 h-4 w-4" />
-                Add
+                {t('form.common.add')}
               </Button>
             </div>
           </div>
@@ -164,11 +168,11 @@ export default function ShirtVariantsTab({
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Color</TableHead>
-                  <TableHead>Size</TableHead>
+                  <TableHead>{t('form.shirtVariants.table.color')}</TableHead>
+                  <TableHead>{t('form.shirtVariants.table.size')}</TableHead>
 
-                  <TableHead>Example Image</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
+                  <TableHead>{t('form.shirtVariants.table.exampleImage')}</TableHead>
+                  <TableHead className="text-right">{t('form.common.actions')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -177,7 +181,7 @@ export default function ShirtVariantsTab({
                     <TableCell>{variant.color}</TableCell>
                     <TableCell>{variant.size}</TableCell>
 
-                    <TableCell>{variant.exampleImageUrl ? 'Yes' : '-'}</TableCell>
+                    <TableCell>{variant.exampleImageUrl ? t('form.common.yes') : '-'}</TableCell>
                     <TableCell className="text-right">
                       <Button variant="ghost" size="sm" onClick={() => handleDeleteVariant(variant.id)}>
                         <Trash2 className="h-4 w-4" />
@@ -196,11 +200,11 @@ export default function ShirtVariantsTab({
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Color</TableHead>
-                  <TableHead>Size</TableHead>
+                  <TableHead>{t('form.shirtVariants.table.color')}</TableHead>
+                  <TableHead>{t('form.shirtVariants.table.size')}</TableHead>
 
-                  <TableHead>Example Image</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
+                  <TableHead>{t('form.shirtVariants.table.exampleImage')}</TableHead>
+                  <TableHead className="text-right">{t('form.common.actions')}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>


### PR DESCRIPTION
## Summary
- integrate the admin article editor shell with i18n driven breadcrumbs, actions and tabs
- localize article general, pricing, mug and shirt detail/variant forms including status badges and toasts
- add English and German translation entries for the new admin article form copy

## Testing
- npm run lint
- npm run type-check
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cb3e8aaa8c8321a38dc57864169fce