### PR TITLE
Localize admin copy variants screens

### DIFF
--- a/frontend/src/locales/de/admin-articles.json
+++ b/frontend/src/locales/de/admin-articles.json
@@ -7,6 +7,68 @@
     "variants": "{{count}} Variante",
     "variants_plural": "{{count}} Varianten"
   },
+  "copyVariants": {
+    "actions": {
+      "cancel": "Abbrechen",
+      "copy": "Varianten kopieren",
+      "copySelected": "{{count}} Variante kopieren",
+      "copySelected_plural": "{{count}} Varianten kopieren",
+      "copying": "Varianten werden kopiert..."
+    },
+    "breadcrumb": {
+      "back": "Zurück zum Artikel",
+      "current": "Varianten kopieren"
+    },
+    "description": "Wähle Varianten bestehender Tassen aus, um sie zum aktuellen Artikel zu kopieren. Du kannst einzelne Varianten auswählen oder Sammelaktionen nutzen.",
+    "empty": {
+      "noOtherMugs": {
+        "description": "Es gibt keine anderen Tassen mit Varianten, von denen kopiert werden kann. Lege zunächst Varianten bei anderen Tassen an.",
+        "title": "Keine weiteren Tassen gefunden"
+      },
+      "noResults": {
+        "description": "Keine Tassen oder Varianten entsprechen deiner Suche. Versuche einen anderen Suchbegriff.",
+        "title": "Keine Ergebnisse gefunden"
+      },
+      "noVariants": {
+        "description": "Es gibt zwar andere Tassen im System, aber keine davon hat Varianten zum Kopieren. Lege zuerst Varianten bei anderen Tassen an.",
+        "title": "Keine Varianten verfügbar"
+      }
+    },
+    "error": {
+      "fetchFailed": "Tassen und Varianten konnten nicht geladen werden. Bitte versuche es erneut.",
+      "retry": "Erneut versuchen"
+    },
+    "footer": {
+      "noneSelected": "Keine Varianten ausgewählt",
+      "selected": "{{count}} Variante ausgewählt",
+      "selected_plural": "{{count}} Varianten ausgewählt"
+    },
+    "loading": "Tassen und Varianten werden geladen...",
+    "search": {
+      "clear": "Zurücksetzen",
+      "placeholder": "Tassen, Lieferanten oder Varianten suchen...",
+      "title": "Suche und Filter"
+    },
+    "table": {
+      "articleNumber": "Artikelnummer",
+      "colors": "Farben",
+      "imageAlt": "Beispiel für {{name}}",
+      "insideColorTitle": "Innen: {{color}}",
+      "outsideColorTitle": "Außen: {{color}}",
+      "preview": "Vorschau",
+      "status": "Status",
+      "supplierLabel": "Lieferant: {{supplier}}",
+      "variantName": "Variantenname"
+    },
+    "title": "Tassenvarianten kopieren",
+    "toasts": {
+      "copied": "{{count}} Variante erfolgreich kopiert",
+      "copied_plural": "{{count}} Varianten erfolgreich kopiert",
+      "copyFailed": "Varianten konnten nicht kopiert werden. Bitte versuche es erneut.",
+      "invalidMug": "Ungültige Tassen-ID",
+      "selectVariant": "Bitte wähle mindestens eine Variante zum Kopieren aus"
+    }
+  },
   "form": {
     "actions": {
       "create": "Artikel erstellen",
@@ -145,6 +207,68 @@
       "actions": {
         "add": "Variante hinzufügen",
         "copy": "Varianten kopieren"
+      },
+      "dialog": {
+        "actions": {
+          "add": "Variante hinzufügen",
+          "cancel": "Abbrechen",
+          "saving": "Speichern...",
+          "update": "Variante aktualisieren",
+          "uploadImage": "Bild hochladen"
+        },
+        "activeDescription": "Variante ist aktiv und für Kund:innen sichtbar",
+        "activeStatus": "Aktiver Status",
+        "cropper": {
+          "description": "Wähle den Bereich aus, der als Varianten-Vorschaubild verwendet werden soll",
+          "title": "Bild für Variante zuschneiden"
+        },
+        "defaultVariant": "Standardvariante",
+        "description": {
+          "add": "Erstelle eine neue Tassenvariante mit unterschiedlichen Farben und Einstellungen",
+          "edit": "Aktualisiere die Variantendaten unten"
+        },
+        "errors": {
+          "createFailed": "Variante konnte nicht hinzugefügt werden",
+          "duplicateName": "Eine Variante mit diesem Namen existiert bereits",
+          "imageTooLarge": "Dateigröße überschreitet die maximal erlaubten 10 MB",
+          "invalidImageType": "Bitte lade eine Bilddatei hoch",
+          "nameRequired": "Bitte gib einen Variantennamen ein",
+          "processCropped": "Zugeschnittenes Bild konnte nicht verarbeitet werden",
+          "removeImage": "Bild konnte nicht entfernt werden",
+          "updateFailed": "Variante konnte nicht aktualisiert werden",
+          "uploadFailedCreate": "Variante erstellt, aber der Bild-Upload ist fehlgeschlagen",
+          "uploadFailedUpdate": "Variante aktualisiert, aber der Bild-Upload ist fehlgeschlagen"
+        },
+        "exampleImage": "Beispielbild",
+        "fields": {
+          "articleVariantNumber": {
+            "label": "Artikelvariantennummer",
+            "placeholder": "z. B. MUG-001"
+          },
+          "name": {
+            "label": "Name *",
+            "placeholder": "z. B. Klassisch Weiß"
+          }
+        },
+        "previewAlt": "Vorschau",
+        "setAsDefault": "Als Standardvariante festlegen",
+        "title": {
+          "add": "Neue Tassenvariante hinzufügen",
+          "edit": "Tassenvariante bearbeiten"
+        },
+        "toasts": {
+          "image": {
+            "removed": "Bild erfolgreich entfernt"
+          },
+          "success": {
+            "create": "Variante erfolgreich hinzugefügt",
+            "update": "Variante erfolgreich aktualisiert"
+          },
+          "temporary": {
+            "added": "Variante hinzugefügt (wird mit dem Artikel gespeichert)",
+            "updated": "Variante aktualisiert (wird mit dem Artikel gespeichert)"
+          }
+        }
       },
       "confirmation": {
         "confirm": "Variante löschen",

--- a/frontend/src/locales/en/admin-articles.json
+++ b/frontend/src/locales/en/admin-articles.json
@@ -7,6 +7,68 @@
     "variants": "{{count}} variant",
     "variants_plural": "{{count}} variants"
   },
+  "copyVariants": {
+    "actions": {
+      "cancel": "Cancel",
+      "copy": "Copy Variants",
+      "copySelected": "Copy {{count}} Variant",
+      "copySelected_plural": "Copy {{count}} Variants",
+      "copying": "Copying..."
+    },
+    "breadcrumb": {
+      "back": "Back to Article",
+      "current": "Copy Variants"
+    },
+    "description": "Select variants from existing mugs to copy to the current mug. You can select individual variants or use bulk actions.",
+    "empty": {
+      "noOtherMugs": {
+        "description": "There are no other mugs with variants available to copy from. Create some variants on other mugs first.",
+        "title": "No Other Mugs Found"
+      },
+      "noResults": {
+        "description": "No mugs or variants match your search criteria. Try a different search term.",
+        "title": "No Results Found"
+      },
+      "noVariants": {
+        "description": "While there are other mugs in the system, none of them have variants to copy. Create some variants on other mugs first.",
+        "title": "No Variants Available"
+      }
+    },
+    "error": {
+      "fetchFailed": "Failed to load mugs and variants. Please try again.",
+      "retry": "Retry"
+    },
+    "footer": {
+      "noneSelected": "No variants selected",
+      "selected": "{{count}} variant selected",
+      "selected_plural": "{{count}} variants selected"
+    },
+    "loading": "Loading mugs and variants...",
+    "search": {
+      "clear": "Clear",
+      "placeholder": "Search mugs, suppliers, or variants...",
+      "title": "Search and Filter"
+    },
+    "table": {
+      "articleNumber": "Article Number",
+      "colors": "Colors",
+      "imageAlt": "{{name}} example",
+      "insideColorTitle": "Inside: {{color}}",
+      "outsideColorTitle": "Outside: {{color}}",
+      "preview": "Preview",
+      "status": "Status",
+      "supplierLabel": "Supplier: {{supplier}}",
+      "variantName": "Variant Name"
+    },
+    "title": "Copy Mug Variants",
+    "toasts": {
+      "copied": "Successfully copied {{count}} variant",
+      "copied_plural": "Successfully copied {{count}} variants",
+      "copyFailed": "Failed to copy variants. Please try again.",
+      "invalidMug": "Invalid mug ID",
+      "selectVariant": "Please select at least one variant to copy"
+    }
+  },
   "form": {
     "actions": {
       "create": "Create Article",
@@ -145,6 +207,68 @@
       "actions": {
         "add": "Add Variant",
         "copy": "Copy Variants"
+      },
+      "dialog": {
+        "actions": {
+          "add": "Add Variant",
+          "cancel": "Cancel",
+          "saving": "Saving...",
+          "update": "Update Variant",
+          "uploadImage": "Upload Image"
+        },
+        "activeDescription": "Variant is active and visible to customers",
+        "activeStatus": "Active Status",
+        "cropper": {
+          "description": "Select the area you want to use for the variant thumbnail",
+          "title": "Crop your variant image"
+        },
+        "defaultVariant": "Default Variant",
+        "description": {
+          "add": "Create a new mug variant with different colors and settings",
+          "edit": "Update the variant details below"
+        },
+        "errors": {
+          "createFailed": "Failed to add variant",
+          "duplicateName": "A variant with this name already exists",
+          "imageTooLarge": "File size exceeds maximum allowed size of 10MB",
+          "invalidImageType": "Please upload an image file",
+          "nameRequired": "Please enter a variant name",
+          "processCropped": "Failed to process cropped image",
+          "removeImage": "Failed to remove image",
+          "updateFailed": "Failed to update variant",
+          "uploadFailedCreate": "Variant created but image upload failed",
+          "uploadFailedUpdate": "Variant updated but image upload failed"
+        },
+        "exampleImage": "Example Image",
+        "fields": {
+          "articleVariantNumber": {
+            "label": "Article Variant Number",
+            "placeholder": "e.g., MUG-001"
+          },
+          "name": {
+            "label": "Name *",
+            "placeholder": "e.g., Classic White"
+          }
+        },
+        "previewAlt": "Preview",
+        "setAsDefault": "Set as default variant",
+        "title": {
+          "add": "Add New Mug Variant",
+          "edit": "Edit Mug Variant"
+        },
+        "toasts": {
+          "image": {
+            "removed": "Image removed successfully"
+          },
+          "success": {
+            "create": "Variant added successfully",
+            "update": "Variant updated successfully"
+          },
+          "temporary": {
+            "added": "Variant added (will be saved with article)",
+            "updated": "Variant updated (will be saved with article)"
+          }
+        }
       },
       "confirmation": {
         "confirm": "Delete Variant",


### PR DESCRIPTION
## Summary
- localize the admin copy variants page and mug variant dialog with i18next
- add English and German translations for the copy variants workflow

## Testing
- npm run lint
- npm run type-check
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cc7d503a6483219a4bc9b7c0e5ccfe