### PR TITLE
Localize admin category dialogs and layout

### DIFF
--- a/frontend/src/components/admin/AdminLayout.tsx
+++ b/frontend/src/components/admin/AdminLayout.tsx
@@ -3,10 +3,24 @@ import { Button } from '@/components/ui/Button';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/Sheet';
 import { Menu } from 'lucide-react';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Outlet } from 'react-router-dom';
 
-export default function AdminLayout() {
+interface AdminLayoutProps {
+  screenReaderLabels?: {
+    navigationDescription?: string;
+    navigationTitle?: string;
+    toggleMenu?: string;
+  };
+}
+
+export default function AdminLayout({ screenReaderLabels }: AdminLayoutProps = {}) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const { t } = useTranslation('adminLayout');
+
+  const toggleMenuLabel = screenReaderLabels?.toggleMenu ?? t('mobileMenu.toggle');
+  const navigationTitle = screenReaderLabels?.navigationTitle ?? t('navigation.title');
+  const navigationDescription = screenReaderLabels?.navigationDescription ?? t('navigation.description');
 
   const handleMobileMenuClose = () => {
     setMobileMenuOpen(false);
@@ -26,13 +40,13 @@ export default function AdminLayout() {
           <SheetTrigger asChild>
             <Button variant="outline" size="icon" className="absolute top-4 left-4 z-40 bg-white shadow-md md:hidden">
               <Menu className="h-5 w-5" />
-              <span className="sr-only">Toggle menu</span>
+              <span className="sr-only">{toggleMenuLabel}</span>
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="w-64 p-0">
             <SheetHeader className="sr-only">
-              <SheetTitle>Admin Navigation Menu</SheetTitle>
-              <SheetDescription>Navigate through admin sections</SheetDescription>
+              <SheetTitle>{navigationTitle}</SheetTitle>
+              <SheetDescription>{navigationDescription}</SheetDescription>
             </SheetHeader>
             <AdminSidebar onNavigate={handleMobileMenuClose} />
           </SheetContent>

--- a/frontend/src/components/admin/categories/CategoryFormDialog.tsx
+++ b/frontend/src/components/admin/categories/CategoryFormDialog.tsx
@@ -6,6 +6,7 @@ import type { CreatePromptCategoryRequest, UpdatePromptCategoryRequest } from '@
 import { promptCategoriesApi } from '@/lib/api';
 import { PromptCategory } from '@/types/prompt';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface CategoryFormDialogProps {
   open: boolean;
@@ -20,7 +21,8 @@ export default function CategoryFormDialog({ open, onOpenChange, category, onSav
     name: '',
   });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [errorKey, setErrorKey] = useState<string | null>(null);
+  const { t } = useTranslation('adminPromptCategories');
 
   useEffect(() => {
     if (category) {
@@ -32,20 +34,20 @@ export default function CategoryFormDialog({ open, onOpenChange, category, onSav
         name: '',
       });
     }
-    setError(null);
+    setErrorKey(null);
   }, [category, open]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!formData.name.trim()) {
-      setError('Name is required');
+      setErrorKey('forms.common.errors.nameRequired');
       return;
     }
 
     try {
       setLoading(true);
-      setError(null);
+      setErrorKey(null);
 
       if (isEditing && category) {
         const updateData: UpdatePromptCategoryRequest = {
@@ -60,7 +62,7 @@ export default function CategoryFormDialog({ open, onOpenChange, category, onSav
       onOpenChange(false);
     } catch (error) {
       console.error('Error saving category:', error);
-      setError('Failed to save category. Please try again.');
+      setErrorKey('forms.category.errors.saveFailed');
     } finally {
       setLoading(false);
     }
@@ -71,28 +73,28 @@ export default function CategoryFormDialog({ open, onOpenChange, category, onSav
       <DialogContent className="sm:max-w-[425px]">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>{isEditing ? 'Edit Category' : 'New Category'}</DialogTitle>
-            <DialogDescription>{isEditing ? 'Update the category details below' : 'Create a new category with the form below'}</DialogDescription>
+            <DialogTitle>{isEditing ? t('forms.category.title.edit') : t('forms.category.title.create')}</DialogTitle>
+            <DialogDescription>{isEditing ? t('forms.category.description.edit') : t('forms.category.description.create')}</DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
-            {error && <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>}
+            {errorKey && <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{t(errorKey)}</div>}
             <div className="grid gap-2">
-              <Label htmlFor="name">Name</Label>
+              <Label htmlFor="name">{t('forms.common.labels.name')}</Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                placeholder="Enter category name"
+                placeholder={t('forms.category.placeholders.name')}
                 required
               />
             </div>
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
+              {t('forms.common.actions.cancel')}
             </Button>
             <Button type="submit" disabled={loading}>
-              {loading ? 'Saving...' : isEditing ? 'Update' : 'Create'}
+              {loading ? t('forms.common.actions.saving') : isEditing ? t('forms.common.actions.update') : t('forms.common.actions.create')}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/admin/categories/SubCategoryFormDialog.tsx
+++ b/frontend/src/components/admin/categories/SubCategoryFormDialog.tsx
@@ -8,6 +8,7 @@ import type { CreatePromptSubCategoryRequest, UpdatePromptSubCategoryRequest } f
 import { promptSubCategoriesApi } from '@/lib/api';
 import { PromptCategory, PromptSubCategory } from '@/types/prompt';
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface SubCategoryFormDialogProps {
   open: boolean;
@@ -26,7 +27,8 @@ export default function SubCategoryFormDialog({ open, onOpenChange, subcategory,
     description: '',
   });
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [errorKey, setErrorKey] = useState<string | null>(null);
+  const { t } = useTranslation('adminPromptCategories');
 
   useEffect(() => {
     if (subcategory) {
@@ -42,25 +44,25 @@ export default function SubCategoryFormDialog({ open, onOpenChange, subcategory,
         description: '',
       });
     }
-    setError(null);
+    setErrorKey(null);
   }, [subcategory, categoryId, open]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!formData.name.trim()) {
-      setError('Name is required');
+      setErrorKey('forms.common.errors.nameRequired');
       return;
     }
 
     if (!formData.promptCategoryId) {
-      setError('Category is required');
+      setErrorKey('forms.common.errors.categoryRequired');
       return;
     }
 
     try {
       setLoading(true);
-      setError(null);
+      setErrorKey(null);
 
       if (isEditing && subcategory) {
         const updateData: UpdatePromptSubCategoryRequest = {
@@ -77,7 +79,7 @@ export default function SubCategoryFormDialog({ open, onOpenChange, subcategory,
       onOpenChange(false);
     } catch (error) {
       console.error('Error saving subcategory:', error);
-      setError('Failed to save subcategory. Please try again.');
+      setErrorKey('forms.subcategory.errors.saveFailed');
     } finally {
       setLoading(false);
     }
@@ -88,21 +90,19 @@ export default function SubCategoryFormDialog({ open, onOpenChange, subcategory,
       <DialogContent className="sm:max-w-[525px]">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>{isEditing ? 'Edit Subcategory' : 'New Subcategory'}</DialogTitle>
-            <DialogDescription>
-              {isEditing ? 'Update the subcategory details below' : 'Create a new subcategory with the form below'}
-            </DialogDescription>
+            <DialogTitle>{isEditing ? t('forms.subcategory.title.edit') : t('forms.subcategory.title.create')}</DialogTitle>
+            <DialogDescription>{isEditing ? t('forms.subcategory.description.edit') : t('forms.subcategory.description.create')}</DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
-            {error && <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>}
+            {errorKey && <div className="rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{t(errorKey)}</div>}
             <div className="grid gap-2">
-              <Label htmlFor="category">Category</Label>
+              <Label htmlFor="category">{t('forms.common.labels.category')}</Label>
               <Select
                 value={formData.promptCategoryId.toString()}
                 onValueChange={(value) => setFormData({ ...formData, promptCategoryId: parseInt(value) })}
               >
                 <SelectTrigger id="category">
-                  <SelectValue placeholder="Select a category" />
+                  <SelectValue placeholder={t('forms.common.placeholders.category')} />
                 </SelectTrigger>
                 <SelectContent>
                   {categories.map((category) => (
@@ -114,32 +114,32 @@ export default function SubCategoryFormDialog({ open, onOpenChange, subcategory,
               </Select>
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="name">Name</Label>
+              <Label htmlFor="name">{t('forms.common.labels.name')}</Label>
               <Input
                 id="name"
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                placeholder="Enter subcategory name"
+                placeholder={t('forms.subcategory.placeholders.name')}
                 required
               />
             </div>
             <div className="grid gap-2">
-              <Label htmlFor="description">Description</Label>
+              <Label htmlFor="description">{t('forms.common.labels.description')}</Label>
               <Textarea
                 id="description"
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                placeholder="Enter subcategory description (optional)"
+                placeholder={t('forms.subcategory.placeholders.description')}
                 rows={3}
               />
             </div>
           </div>
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-              Cancel
+              {t('forms.common.actions.cancel')}
             </Button>
             <Button type="submit" disabled={loading}>
-              {loading ? 'Saving...' : isEditing ? 'Update' : 'Create'}
+              {loading ? t('forms.common.actions.saving') : isEditing ? t('forms.common.actions.update') : t('forms.common.actions.create')}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,4 +1,5 @@
 import { useSession } from '@/hooks/queries/useAuth';
+import { useTranslation } from 'react-i18next';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 interface ProtectedRouteProps {
@@ -8,11 +9,12 @@ interface ProtectedRouteProps {
 export default function ProtectedRoute({ requiredRoles = [] }: ProtectedRouteProps) {
   const { data: session, isLoading } = useSession();
   const location = useLocation();
+  const { t } = useTranslation('common');
 
   if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="text-lg">Loading...</div>
+        <div className="text-lg">{t('loading')}</div>
       </div>
     );
   }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -4,6 +4,7 @@ import { initReactI18next } from 'react-i18next';
 import deAdminArticleCategories from './locales/de/admin-article-categories.json';
 import deAdminArticles from './locales/de/admin-articles.json';
 import deAdminCompletedOrders from './locales/de/admin-completed-orders.json';
+import deAdminLayout from './locales/de/admin-layout.json';
 import deAdminLogistics from './locales/de/admin-logistics.json';
 import deAdminOpenOrders from './locales/de/admin-open-orders.json';
 import deAdminPromptCategories from './locales/de/admin-prompt-categories.json';
@@ -31,6 +32,7 @@ import deVat from './locales/de/vat.json';
 import enAdminArticleCategories from './locales/en/admin-article-categories.json';
 import enAdminArticles from './locales/en/admin-articles.json';
 import enAdminCompletedOrders from './locales/en/admin-completed-orders.json';
+import enAdminLayout from './locales/en/admin-layout.json';
 import enAdminLogistics from './locales/en/admin-logistics.json';
 import enAdminOpenOrders from './locales/en/admin-open-orders.json';
 import enAdminPromptCategories from './locales/en/admin-prompt-categories.json';
@@ -94,6 +96,7 @@ export const resources = {
     adminSuppliers: enAdminSuppliers,
     adminCompletedOrders: enAdminCompletedOrders,
     adminLogistics: enAdminLogistics,
+    adminLayout: enAdminLayout,
     articleCategory: enAdminArticleCategory,
     articleSubCategory: enAdminArticleSubCategory,
     cart: enCart,
@@ -124,6 +127,7 @@ export const resources = {
     adminSuppliers: deAdminSuppliers,
     adminCompletedOrders: deAdminCompletedOrders,
     adminLogistics: deAdminLogistics,
+    adminLayout: deAdminLayout,
     articleCategory: deAdminArticleCategory,
     articleSubCategory: deAdminArticleSubCategory,
     cart: deCart,

--- a/frontend/src/locales/de/admin-layout.json
+++ b/frontend/src/locales/de/admin-layout.json
@@ -1,0 +1,9 @@
+{
+  "mobileMenu": {
+    "toggle": "Menü umschalten"
+  },
+  "navigation": {
+    "description": "Durch die Admin-Bereiche navigieren",
+    "title": "Admin-Navigationsmenü"
+  }
+}

--- a/frontend/src/locales/de/admin-prompt-categories.json
+++ b/frontend/src/locales/de/admin-prompt-categories.json
@@ -25,6 +25,64 @@
     "category": "Kategorie",
     "subcategory": "Unterkategorie"
   },
+  "forms": {
+    "category": {
+      "description": {
+        "create": "Erstelle über das Formular unten eine neue Kategorie",
+        "edit": "Aktualisiere die Kategoriedetails unten"
+      },
+      "errors": {
+        "saveFailed": "Kategorie konnte nicht gespeichert werden. Bitte versuche es erneut."
+      },
+      "placeholders": {
+        "name": "Kategorienamen eingeben"
+      },
+      "title": {
+        "create": "Neue Kategorie",
+        "edit": "Kategorie bearbeiten"
+      }
+    },
+    "common": {
+      "actions": {
+        "cancel": "Abbrechen",
+        "create": "Erstellen",
+        "saving": "Speichern...",
+        "update": "Aktualisieren"
+      },
+      "errors": {
+        "categoryRequired": "Kategorie ist erforderlich",
+        "nameRequired": "Name ist erforderlich",
+        "saveFailed": "Speichern fehlgeschlagen. Bitte versuche es erneut."
+      },
+      "labels": {
+        "category": "Kategorie",
+        "description": "Beschreibung",
+        "name": "Name"
+      },
+      "placeholders": {
+        "category": "Kategorie auswählen",
+        "description": "Beschreibung eingeben (optional)",
+        "name": "Name eingeben"
+      }
+    },
+    "subcategory": {
+      "description": {
+        "create": "Erstelle über das Formular unten eine neue Unterkategorie",
+        "edit": "Aktualisiere die Unterkategoriedetails unten"
+      },
+      "errors": {
+        "saveFailed": "Unterkategorie konnte nicht gespeichert werden. Bitte versuche es erneut."
+      },
+      "placeholders": {
+        "description": "Unterkategoriebeschreibung eingeben (optional)",
+        "name": "Unterkategorienamen eingeben"
+      },
+      "title": {
+        "create": "Neue Unterkategorie",
+        "edit": "Unterkategorie bearbeiten"
+      }
+    }
+  },
   "page": {
     "error": {
       "loadFailed": "Kategorien konnten nicht geladen werden. Bitte versuchen Sie es erneut."

--- a/frontend/src/locales/en/admin-layout.json
+++ b/frontend/src/locales/en/admin-layout.json
@@ -1,0 +1,9 @@
+{
+  "mobileMenu": {
+    "toggle": "Toggle menu"
+  },
+  "navigation": {
+    "description": "Navigate through admin sections",
+    "title": "Admin Navigation Menu"
+  }
+}

--- a/frontend/src/locales/en/admin-prompt-categories.json
+++ b/frontend/src/locales/en/admin-prompt-categories.json
@@ -25,6 +25,64 @@
     "category": "category",
     "subcategory": "subcategory"
   },
+  "forms": {
+    "category": {
+      "description": {
+        "create": "Create a new category with the form below",
+        "edit": "Update the category details below"
+      },
+      "errors": {
+        "saveFailed": "Failed to save category. Please try again."
+      },
+      "placeholders": {
+        "name": "Enter category name"
+      },
+      "title": {
+        "create": "New Category",
+        "edit": "Edit Category"
+      }
+    },
+    "common": {
+      "actions": {
+        "cancel": "Cancel",
+        "create": "Create",
+        "saving": "Saving...",
+        "update": "Update"
+      },
+      "errors": {
+        "categoryRequired": "Category is required",
+        "nameRequired": "Name is required",
+        "saveFailed": "Failed to save. Please try again."
+      },
+      "labels": {
+        "category": "Category",
+        "description": "Description",
+        "name": "Name"
+      },
+      "placeholders": {
+        "category": "Select a category",
+        "description": "Enter description (optional)",
+        "name": "Enter name"
+      }
+    },
+    "subcategory": {
+      "description": {
+        "create": "Create a new subcategory with the form below",
+        "edit": "Update the subcategory details below"
+      },
+      "errors": {
+        "saveFailed": "Failed to save subcategory. Please try again."
+      },
+      "placeholders": {
+        "description": "Enter subcategory description (optional)",
+        "name": "Enter subcategory name"
+      },
+      "title": {
+        "create": "New Subcategory",
+        "edit": "Edit Subcategory"
+      }
+    }
+  },
   "page": {
     "error": {
       "loadFailed": "Failed to load categories. Please try again."

--- a/frontend/src/routes/AdminRoutes.tsx
+++ b/frontend/src/routes/AdminRoutes.tsx
@@ -1,4 +1,5 @@
 import { lazy } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Route, Routes } from 'react-router-dom';
 
 // Lazy load all admin components
@@ -26,9 +27,21 @@ const Suppliers = lazy(() => import('@/pages/admin/Suppliers'));
 const Vat = lazy(() => import('@/pages/admin/Vat'));
 
 export function AdminRoutes() {
+  const { t } = useTranslation('adminLayout');
+
   return (
     <Routes>
-      <Route element={<AdminLayout />}>
+      <Route
+        element={
+          <AdminLayout
+            screenReaderLabels={{
+              navigationDescription: t('navigation.description'),
+              navigationTitle: t('navigation.title'),
+              toggleMenu: t('mobileMenu.toggle'),
+            }}
+          />
+        }
+      >
         <Route index element={<Prompts />} />
         <Route path="prompts" element={<Prompts />} />
         <Route path="prompts/new" element={<NewOrEditPrompt />} />


### PR DESCRIPTION
## Summary
- wire admin layout, protected route, and category dialogs up to i18next so screen reader labels and form copy translate correctly
- add English and German resources for the admin layout strings plus prompt category and subcategory form messaging
- surface localized screen reader labels through the admin routes entry point and register the new namespaces with i18n

## Testing
- npm run lint
- npm run type-check
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cc8017f86483219e0b6b8725ee7e98