### PR TITLE
Localize cart media messaging

### DIFF
--- a/frontend/src/components/CartItemImage.tsx
+++ b/frontend/src/components/CartItemImage.tsx
@@ -1,5 +1,6 @@
 import { useImageWithFallback } from '@/hooks/useImageWithFallback';
 import { AlertCircle, RefreshCw, ShoppingBag } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { ImageSkeleton } from './ImageSkeleton';
 import { Button } from './ui/Button';
 
@@ -12,6 +13,7 @@ interface CartItemImageProps {
 }
 
 export function CartItemImage({ src, alt, className = 'h-24 w-24 rounded-md object-cover sm:h-32 sm:w-32', onLoad, onError }: CartItemImageProps) {
+  const { t } = useTranslation('cart');
   const { retryCount, retry, isLoading, isLoaded, isError, isRetrying } = useImageWithFallback(src, {
     maxRetries: 3,
     retryDelay: 1000,
@@ -38,7 +40,7 @@ export function CartItemImage({ src, alt, className = 'h-24 w-24 rounded-md obje
         <div className={`flex items-center justify-center bg-gray-100 ${className}`}>
           <div className="text-center">
             <RefreshCw className="mx-auto h-6 w-6 animate-spin text-gray-400" />
-            <p className="mt-1 text-xs text-gray-500">Retrying...</p>
+            <p className="mt-1 text-xs text-gray-500">{t('image.retrying')}</p>
           </div>
         </div>
       </div>
@@ -51,10 +53,10 @@ export function CartItemImage({ src, alt, className = 'h-24 w-24 rounded-md obje
       <div className={containerClasses}>
         <div className={`flex flex-col items-center justify-center bg-gray-100 ${className} p-2`}>
           <AlertCircle className="mb-1 h-6 w-6 text-red-400" />
-          <p className="mb-2 text-center text-xs text-gray-600">{retryCount > 0 ? 'Failed to load' : 'Image error'}</p>
+          <p className="mb-2 text-center text-xs text-gray-600">{retryCount > 0 ? t('image.failed') : t('image.error')}</p>
           <Button variant="outline" size="sm" onClick={retry} className="h-auto px-2 py-1 text-xs">
             <RefreshCw className="mr-1 h-3 w-3" />
-            Retry
+            {t('image.retry')}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/LazyLoadingFallback.tsx
+++ b/frontend/src/components/LazyLoadingFallback.tsx
@@ -1,15 +1,18 @@
+import { useTranslation } from 'react-i18next';
 import { LoadingSpinner } from './LoadingSpinner';
 
 interface LazyLoadingFallbackProps {
   message?: string;
 }
 
-export function LazyLoadingFallback({ message = 'Loading...' }: LazyLoadingFallbackProps) {
+export function LazyLoadingFallback({ message }: LazyLoadingFallbackProps) {
+  const { t } = useTranslation('common');
+  const displayMessage = message ?? t('loading');
   return (
     <div className="flex h-screen items-center justify-center">
       <div className="text-center">
         <LoadingSpinner className="mx-auto mb-4 h-8 w-8" />
-        <p className="text-sm text-gray-600">{message}</p>
+        <p className="text-sm text-gray-600">{displayMessage}</p>
       </div>
     </div>
   );

--- a/frontend/src/components/editor/components/shared/MugPreview3D.tsx
+++ b/frontend/src/components/editor/components/shared/MugPreview3D.tsx
@@ -2,6 +2,7 @@ import { getCroppedImgFromArea } from '@/lib/imageCropUtils';
 import { Environment, OrbitControls } from '@react-three/drei';
 import { Canvas, useFrame, useLoader } from '@react-three/fiber';
 import { Suspense, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import * as THREE from 'three';
 import { GeneratedImageCropData, MugOption } from '../../types';
 
@@ -89,6 +90,7 @@ function LoadingSpinner() {
 export default function MugPreview3D({ imageUrl, cropData }: MugPreview3DProps) {
   const [processedImageUrl, setProcessedImageUrl] = useState<string | null>(null);
   const [isProcessing, setIsProcessing] = useState(true);
+  const { t } = useTranslation('editor');
 
   useEffect(() => {
     const processImage = async () => {
@@ -149,7 +151,7 @@ export default function MugPreview3D({ imageUrl, cropData }: MugPreview3DProps) 
       </Canvas>
 
       {/* Instructions */}
-      <div className="mt-2 text-center text-sm text-gray-600">Drag to rotate • Scroll to zoom</div>
+      <div className="mt-2 text-center text-sm text-gray-600">{t('steps.preview.controlsHint')}</div>
     </div>
   );
 }

--- a/frontend/src/locales/de/cart.json
+++ b/frontend/src/locales/de/cart.json
@@ -18,6 +18,12 @@
     "checkout": "Zur Kasse • {{amount}}"
   },
   "currency": "{{value}} €",
+  "image": {
+    "error": "Bildfehler",
+    "failed": "Laden fehlgeschlagen",
+    "retry": "Erneut versuchen",
+    "retrying": "Erneuter Versuch..."
+  },
   "item": {
     "variantLabel": "Variante: {{color}}",
     "priceWas": "(vorher {{amount}})",

--- a/frontend/src/locales/de/editor.json
+++ b/frontend/src/locales/de/editor.json
@@ -173,6 +173,7 @@
     "preview": {
       "title": "Perfektioniere dein Design",
       "subtitle": "Positioniere und skaliere dein Design links und sieh die Live-Vorschau rechts",
+      "controlsHint": "Zum Drehen ziehen • Zum Zoomen scrollen",
       "cropper": {
         "title": "Design positionieren und skalieren",
         "description": "Ziehe, um dein Bild zu verschieben, und nutze den Regler zum Zoomen",

--- a/frontend/src/locales/en/cart.json
+++ b/frontend/src/locales/en/cart.json
@@ -18,6 +18,12 @@
     "checkout": "Checkout • {{amount}}"
   },
   "currency": "${{value}}",
+  "image": {
+    "error": "Image error",
+    "failed": "Failed to load",
+    "retry": "Retry",
+    "retrying": "Retrying..."
+  },
   "item": {
     "variantLabel": "Variant: {{color}}",
     "priceWas": "(was {{amount}})",

--- a/frontend/src/locales/en/editor.json
+++ b/frontend/src/locales/en/editor.json
@@ -169,6 +169,7 @@
     "preview": {
       "title": "Perfect Your Design",
       "subtitle": "Position and scale your design on the left, and see the live preview on the right",
+      "controlsHint": "Drag to rotate • Scroll to zoom",
       "cropper": {
         "title": "Position and scale your design",
         "description": "Drag to move your image and use the slider to zoom in or out",


### PR DESCRIPTION
## Summary
- localize the cart item image states and lazy loading fallback messaging
- translate the mug preview controls hint and wire it to the editor namespace
- add the necessary English and German strings to the cart and editor locale files

## Testing
- npm run lint
- npm run type-check
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cc835e6970832195b2f5b8853bb1aa