### PR TITLE
Refine prompt LLM selection

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -90,7 +90,7 @@ func main() {
 	// AI image routes (admin)
 	ai.RegisterRoutes(r, db)
 	// Prompt module routes (admin + public)
-	prompt.RegisterRoutes(r, db)
+	prompt.RegisterRoutes(r, db, ai.ProviderLLMIDs())
 	// Article module routes (admin + public)
 	article.RegisterRoutes(r, db)
 	// Cart routes (user)

--- a/backend/internal/ai/handlers.go
+++ b/backend/internal/ai/handlers.go
@@ -67,6 +67,10 @@ func RegisterRoutes(r *gin.Engine, db *gorm.DB) {
 	admin := r.Group("/api/admin/ai")
 	admin.Use(auth.RequireAdmin(db))
 
+	admin.GET("/llms", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"llms": ProviderLLMs()})
+	})
+
 	// POST /api/admin/ai/test-prompt
 	// Multipart form:
 	// - image: file (required)

--- a/backend/internal/ai/handlers_llms_test.go
+++ b/backend/internal/ai/handlers_llms_test.go
@@ -1,0 +1,64 @@
+package ai
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"voenix/backend/internal/auth"
+)
+
+func TestAdminLLMsEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&auth.Role{}, &auth.User{}, &auth.Session{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+	role := auth.Role{Name: "ADMIN"}
+	if err := db.Create(&role).Error; err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+	user := auth.User{Email: "admin@example.com"}
+	if err := db.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := db.Model(&user).Association("Roles").Append(&role); err != nil {
+		t.Fatalf("attach role: %v", err)
+	}
+	expiresAt := time.Now().Add(time.Hour)
+	session := auth.Session{ID: "test-session", UserID: user.ID, ExpiresAt: &expiresAt}
+	if err := db.Create(&session).Error; err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	router := gin.New()
+	RegisterRoutes(router, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/ai/llms", nil)
+	req.AddCookie(&http.Cookie{Name: "session_id", Value: session.ID})
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+	var resp struct {
+		LLMs []ProviderLLM `json:"llms"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.LLMs) != len(ProviderLLMs()) {
+		t.Fatalf("expected %d llms, got %d", len(ProviderLLMs()), len(resp.LLMs))
+	}
+}

--- a/backend/internal/ai/provider_llms.go
+++ b/backend/internal/ai/provider_llms.go
@@ -1,0 +1,42 @@
+package ai
+
+// ProviderLLM describes a supported LLM along with its provider metadata.
+type ProviderLLM struct {
+	Provider     string `json:"provider"`
+	LLM          string `json:"llm"`
+	FriendlyName string `json:"friendlyName"`
+}
+
+var providerLLMs = []ProviderLLM{
+	{
+		Provider:     "Google",
+		LLM:          "gemini-2.5-flash-image-preview",
+		FriendlyName: "Nano Banana (Google)",
+	},
+	{
+		Provider:     "OpenAI",
+		LLM:          "gpt-image-1",
+		FriendlyName: "GTP-Image-1 (OpenAI)",
+	},
+	{
+		Provider:     "Black Forest Labs",
+		LLM:          "flux",
+		FriendlyName: "Flux (Black Forest Labs)",
+	},
+}
+
+// ProviderLLMs returns all configured provider + LLM combinations.
+func ProviderLLMs() []ProviderLLM {
+	out := make([]ProviderLLM, len(providerLLMs))
+	copy(out, providerLLMs)
+	return out
+}
+
+// ProviderLLMIDs exposes just the LLM identifiers for validation in other packages.
+func ProviderLLMIDs() []string {
+	ids := make([]string, 0, len(providerLLMs))
+	for i := range providerLLMs {
+		ids = append(ids, providerLLMs[i].LLM)
+	}
+	return ids
+}

--- a/backend/internal/database/migrations/000004_prompt_slot_variant_llm.down.sql
+++ b/backend/internal/database/migrations/000004_prompt_slot_variant_llm.down.sql
@@ -1,0 +1,2 @@
+alter table prompt_slot_variants
+    drop column if exists llm;

--- a/backend/internal/database/migrations/000004_prompt_slot_variant_llm.up.sql
+++ b/backend/internal/database/migrations/000004_prompt_slot_variant_llm.up.sql
@@ -1,0 +1,2 @@
+alter table prompt_slot_variants
+    add column if not exists llm varchar(255);

--- a/backend/internal/prompt/dtos.go
+++ b/backend/internal/prompt/dtos.go
@@ -20,6 +20,7 @@ type PromptSlotVariantRead struct {
 	Prompt           *string             `json:"prompt"`
 	Description      *string             `json:"description"`
 	ExampleImageURL  *string             `json:"exampleImageUrl"`
+	LLM              string              `json:"llm"`
 	CreatedAt        *time.Time          `json:"createdAt"`
 	UpdatedAt        *time.Time          `json:"updatedAt"`
 }

--- a/backend/internal/prompt/entities.go
+++ b/backend/internal/prompt/entities.go
@@ -44,6 +44,7 @@ type PromptSlotVariant struct {
 	Prompt               *string         `gorm:"type:text" json:"prompt"`
 	Description          *string         `gorm:"type:text" json:"description"`
 	ExampleImageFilename *string         `gorm:"size:500" json:"exampleImageFilename"`
+	LLM                  string          `gorm:"size:255" json:"llm"`
 	CreatedAt            time.Time       `json:"createdAt"`
 	UpdatedAt            time.Time       `json:"updatedAt"`
 }

--- a/backend/internal/prompt/handlers.go
+++ b/backend/internal/prompt/handlers.go
@@ -6,8 +6,8 @@ import (
 )
 
 // RegisterRoutes mounts prompt admin and public routes.
-func RegisterRoutes(r *gin.Engine, db *gorm.DB) {
-	svc := newService(db)
+func RegisterRoutes(r *gin.Engine, db *gorm.DB, allowedLLMs []string) {
+	svc := newService(db, allowedLLMs)
 	// Admin
 	registerAdminSlotTypeRoutes(r, db, svc)
 	registerAdminSlotVariantRoutes(r, db, svc)

--- a/backend/internal/prompt/handlers_admin_slot_variants.go
+++ b/backend/internal/prompt/handlers_admin_slot_variants.go
@@ -17,6 +17,7 @@ type slotVariantCreate struct {
 	Prompt               *string `json:"prompt"`
 	Description          *string `json:"description"`
 	ExampleImageFilename *string `json:"exampleImageFilename"`
+	LLM                  string  `json:"llm"`
 }
 
 type slotVariantUpdate struct {
@@ -25,6 +26,7 @@ type slotVariantUpdate struct {
 	Prompt               *string `json:"prompt"`
 	Description          *string `json:"description"`
 	ExampleImageFilename *string `json:"exampleImageFilename"`
+	LLM                  *string `json:"llm"`
 }
 
 func registerAdminSlotVariantRoutes(r *gin.Engine, db *gorm.DB, svc *service) {
@@ -56,7 +58,7 @@ func registerAdminSlotVariantRoutes(r *gin.Engine, db *gorm.DB, svc *service) {
 
 	grp.POST("", func(c *gin.Context) {
 		var payload slotVariantCreate
-		if err := c.ShouldBindJSON(&payload); err != nil || strings.TrimSpace(payload.Name) == "" || payload.PromptSlotTypeID <= 0 {
+		if err := c.ShouldBindJSON(&payload); err != nil || strings.TrimSpace(payload.Name) == "" || payload.PromptSlotTypeID <= 0 || strings.TrimSpace(payload.LLM) == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"detail": "Invalid payload"})
 			return
 		}
@@ -69,6 +71,10 @@ func registerAdminSlotVariantRoutes(r *gin.Engine, db *gorm.DB, svc *service) {
 			var ce conflictError
 			if errors.As(err, &ce) {
 				c.JSON(http.StatusConflict, gin.H{"detail": ce.Detail})
+				return
+			}
+			if errors.Is(err, errInvalidLLM) {
+				c.JSON(http.StatusBadRequest, gin.H{"detail": "Invalid llm selection"})
 				return
 			}
 			c.JSON(http.StatusInternalServerError, gin.H{"detail": "Failed to create slot variant"})
@@ -93,6 +99,10 @@ func registerAdminSlotVariantRoutes(r *gin.Engine, db *gorm.DB, svc *service) {
 			var ce conflictError
 			if errors.As(err, &ce) {
 				c.JSON(http.StatusConflict, gin.H{"detail": ce.Detail})
+				return
+			}
+			if errors.Is(err, errInvalidLLM) {
+				c.JSON(http.StatusBadRequest, gin.H{"detail": "Invalid llm selection"})
 				return
 			}
 			c.JSON(http.StatusInternalServerError, gin.H{"detail": "Failed to update slot variant"})

--- a/backend/internal/prompt/helpers.go
+++ b/backend/internal/prompt/helpers.go
@@ -39,6 +39,7 @@ func toSlotVariantRead(v *PromptSlotVariant) PromptSlotVariantRead {
 		Prompt:           v.Prompt,
 		Description:      v.Description,
 		ExampleImageURL:  strPtrOrNil(publicSlotVariantExampleURL(v.ExampleImageFilename)),
+		LLM:              v.LLM,
 		CreatedAt:        timePtr(v.CreatedAt),
 		UpdatedAt:        timePtr(v.UpdatedAt),
 	}

--- a/backend/internal/prompt/service_slot_variants_test.go
+++ b/backend/internal/prompt/service_slot_variants_test.go
@@ -1,0 +1,107 @@
+package prompt
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"voenix/backend/internal/auth"
+)
+
+func setupPromptServiceTest(t *testing.T) (*service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&PromptSlotType{}, &PromptSlotVariant{}, &auth.Role{}, &auth.User{}, &auth.Session{}); err != nil {
+		t.Fatalf("auto migrate: %v", err)
+	}
+	allowedLLMs := []string{
+		"gemini-2.5-flash-image-preview",
+		"gpt-image-1",
+		"flux",
+	}
+	return newService(db, allowedLLMs), db
+}
+
+func strPtr(v string) *string {
+	return &v
+}
+
+func TestCreateSlotVariantPersistsLLM(t *testing.T) {
+	svc, db := setupPromptServiceTest(t)
+	slotType := PromptSlotType{Name: "Primary", Position: 1}
+	if err := db.Create(&slotType).Error; err != nil {
+		t.Fatalf("seed slot type: %v", err)
+	}
+	promptText := "Example prompt"
+	payload := slotVariantCreate{
+		PromptSlotTypeID:     slotType.ID,
+		Name:                 "Variant A",
+		Prompt:               &promptText,
+		Description:          nil,
+		ExampleImageFilename: nil,
+		LLM:                  "gemini-2.5-flash-image-preview",
+	}
+	created, err := svc.createSlotVariant(context.Background(), payload)
+	if err != nil {
+		t.Fatalf("create slot variant: %v", err)
+	}
+	if created.LLM != "gemini-2.5-flash-image-preview" {
+		t.Fatalf("expected llm gemini-2.5-flash-image-preview, got %s", created.LLM)
+	}
+	var stored PromptSlotVariant
+	if err := db.First(&stored, created.ID).Error; err != nil {
+		t.Fatalf("load stored variant: %v", err)
+	}
+	if stored.LLM != "gemini-2.5-flash-image-preview" {
+		t.Fatalf("expected stored llm gemini-2.5-flash-image-preview, got %s", stored.LLM)
+	}
+}
+
+func TestCreateSlotVariantRejectsInvalidLLM(t *testing.T) {
+	svc, db := setupPromptServiceTest(t)
+	slotType := PromptSlotType{Name: "Primary", Position: 1}
+	if err := db.Create(&slotType).Error; err != nil {
+		t.Fatalf("seed slot type: %v", err)
+	}
+	payload := slotVariantCreate{
+		PromptSlotTypeID:     slotType.ID,
+		Name:                 "Variant B",
+		Prompt:               nil,
+		Description:          nil,
+		ExampleImageFilename: nil,
+		LLM:                  "not-a-real-llm",
+	}
+	if _, err := svc.createSlotVariant(context.Background(), payload); !errors.Is(err, errInvalidLLM) {
+		t.Fatalf("expected errInvalidLLM, got %v", err)
+	}
+}
+
+func TestUpdateSlotVariantValidatesLLM(t *testing.T) {
+	svc, db := setupPromptServiceTest(t)
+	slotType := PromptSlotType{Name: "Primary", Position: 1}
+	if err := db.Create(&slotType).Error; err != nil {
+		t.Fatalf("seed slot type: %v", err)
+	}
+	variant := PromptSlotVariant{PromptSlotTypeID: slotType.ID, Name: "Variant C", LLM: "gpt-image-1"}
+	if err := db.Create(&variant).Error; err != nil {
+		t.Fatalf("seed variant: %v", err)
+	}
+	update := slotVariantUpdate{LLM: strPtr("gemini-2.5-flash-image-preview")}
+	updated, err := svc.updateSlotVariant(context.Background(), variant.ID, update)
+	if err != nil {
+		t.Fatalf("update variant: %v", err)
+	}
+	if updated.LLM != "gemini-2.5-flash-image-preview" {
+		t.Fatalf("expected llm gemini-2.5-flash-image-preview after update, got %s", updated.LLM)
+	}
+	invalid := slotVariantUpdate{LLM: strPtr("  ")}
+	if _, err := svc.updateSlotVariant(context.Background(), variant.ID, invalid); !errors.Is(err, errInvalidLLM) {
+		t.Fatalf("expected errInvalidLLM for blank llm, got %v", err)
+	}
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,7 +17,7 @@ import type { MugWithVariantsSummary } from '@/types/copyVariants';
 import type { Country } from '@/types/country';
 import type { ArticleCategory, ArticleSubCategory, Mug, MugVariant } from '@/types/mug';
 import type { Prompt, PromptCategory, PromptSubCategory } from '@/types/prompt';
-import type { PromptSlotType, PromptSlotVariant } from '@/types/promptSlotVariant';
+import type { PromptSlotType, PromptSlotVariant, ProviderLLM } from '@/types/promptSlotVariant';
 import type { CreateSupplierRequest, Supplier, UpdateSupplierRequest } from '@/types/supplier';
 import type { CreateValueAddedTaxRequest, UpdateValueAddedTaxRequest, ValueAddedTax } from '@/types/vat';
 
@@ -428,6 +428,10 @@ export const promptSlotVariantsApi = {
   delete: (id: number) => api.delete<void>(`/admin/prompts/slot-variants/${id}`),
 };
 
+export const promptLlmsApi = {
+  getAll: () => api.get<{ llms: ProviderLLM[] }>('/admin/ai/llms'),
+};
+
 // Type definitions for Prompt Slot Variant API requests
 export interface CreatePromptSlotVariantRequest {
   promptSlotTypeId: number;
@@ -435,6 +439,7 @@ export interface CreatePromptSlotVariantRequest {
   prompt: string;
   description?: string;
   exampleImageFilename?: string | null;
+  llm: string;
 }
 
 export interface UpdatePromptSlotVariantRequest {
@@ -443,6 +448,7 @@ export interface UpdatePromptSlotVariantRequest {
   prompt?: string;
   description?: string;
   exampleImageFilename?: string | null;
+  llm?: string;
 }
 
 // Image API endpoints

--- a/frontend/src/locales/de/admin/newOrEditPrompt.json
+++ b/frontend/src/locales/de/admin/newOrEditPrompt.json
@@ -22,6 +22,9 @@
     "noSubcategory": "Keine Subkategorie",
     "promptStyle": "Prompt-Stil (optional)",
     "promptStylePlaceholder": "Prompt-Text eingeben...",
+    "llm": "LLM",
+    "llmPlaceholder": "LLM auswählen",
+    "llmEmpty": "Keine LLMs verfügbar. Bitte einen Admin zur Konfiguration bitten.",
     "status": "Status",
     "statusHint": "Diesen Prompt zur Nutzung freigeben"
   },
@@ -34,6 +37,7 @@
     "loadCategories": "Kategorien konnten nicht geladen werden",
     "loadSubcategories": "Unterkategorien konnten nicht geladen werden",
     "load": "Prompt konnte nicht geladen werden",
+    "loadLLMs": "LLM-Optionen konnten nicht geladen werden",
     "save": "Prompt konnte nicht gespeichert werden. Bitte erneut versuchen.",
     "titleRequired": "Titel ist erforderlich",
     "categoryRequired": "Kategorie ist erforderlich",
@@ -52,6 +56,7 @@
       "load": "Slot-Varianten konnten nicht geladen werden"
     },
     "empty": "Keine Slot-Varianten vorhanden. Bitte erstellen Sie zuerst Slot-Varianten.",
+    "filteredEmpty": "Für das ausgewählte LLM sind keine Slot-Varianten vorhanden.",
     "badge": "{{selected}} von {{total}} Typen ausgewählt",
     "selectedBadge": "Ausgewählt",
     "fallbackType": "Andere",

--- a/frontend/src/locales/de/admin/newOrEditPromptSlotVariant.json
+++ b/frontend/src/locales/de/admin/newOrEditPromptSlotVariant.json
@@ -12,6 +12,9 @@
     "namePlaceholder": "Slot-Namen eingeben",
     "type": "Prompt-Slot-Typ",
     "typePlaceholder": "Prompt-Slot-Typ auswählen",
+    "llm": "LLM",
+    "llmPlaceholder": "LLM auswählen",
+    "llmEmpty": "Keine LLMs verfügbar. Bitten Sie einen Admin, LLMs zu konfigurieren.",
     "prompt": "Prompt",
     "promptPlaceholder": "Prompt-Text eingeben",
     "description": "Beschreibung",
@@ -23,10 +26,12 @@
   "errors": {
     "loadTypes": "Prompt-Slot-Typen konnten nicht geladen werden",
     "load": "Slot konnte nicht geladen werden",
+    "loadLLMs": "LLM-Optionen konnten nicht geladen werden",
     "save": "Slot konnte nicht gespeichert werden. Bitte erneut versuchen.",
     "nameRequired": "Name ist erforderlich",
     "typeRequired": "Prompt-Slot-Typ ist erforderlich",
     "promptRequired": "Prompt ist erforderlich",
+    "llmRequired": "LLM ist erforderlich",
     "invalidImage": "Bitte laden Sie eine Bilddatei hoch",
     "imageTooLarge": "Bildgröße muss kleiner als 5 MB sein",
     "uploadImage": "Bild konnte nicht hochgeladen werden. Bitte erneut versuchen."

--- a/frontend/src/locales/en/admin/newOrEditPrompt.json
+++ b/frontend/src/locales/en/admin/newOrEditPrompt.json
@@ -22,6 +22,9 @@
     "noSubcategory": "No subcategory",
     "promptStyle": "Prompt Style (optional)",
     "promptStylePlaceholder": "Enter the prompt text content...",
+    "llm": "LLM",
+    "llmPlaceholder": "Select an LLM",
+    "llmEmpty": "No LLMs available. Ask an admin to configure LLMs.",
     "status": "Status",
     "statusHint": "Make this prompt available for use"
   },
@@ -34,6 +37,7 @@
     "loadCategories": "Failed to load categories",
     "loadSubcategories": "Failed to load subcategories",
     "load": "Failed to load prompt",
+    "loadLLMs": "Failed to load LLM options",
     "save": "Failed to save prompt. Please try again.",
     "titleRequired": "Title is required",
     "categoryRequired": "Category is required",
@@ -52,6 +56,7 @@
       "load": "Failed to load slot variants"
     },
     "empty": "No slot variants available. Please create slot variants first.",
+    "filteredEmpty": "No slot variants are available for the selected LLM.",
     "badge": "{{selected}} of {{total}} types selected",
     "selectedBadge": "Selected",
     "fallbackType": "Other",

--- a/frontend/src/locales/en/admin/newOrEditPromptSlotVariant.json
+++ b/frontend/src/locales/en/admin/newOrEditPromptSlotVariant.json
@@ -12,6 +12,9 @@
     "namePlaceholder": "Enter slot name",
     "type": "Prompt Slot Type",
     "typePlaceholder": "Select a prompt slot type",
+    "llm": "LLM",
+    "llmPlaceholder": "Select an LLM",
+    "llmEmpty": "No LLMs available. Ask an admin to configure LLMs.",
     "prompt": "Prompt",
     "promptPlaceholder": "Enter the prompt text",
     "description": "Description",
@@ -23,10 +26,12 @@
   "errors": {
     "loadTypes": "Failed to load prompt slot types",
     "load": "Failed to load slot",
+    "loadLLMs": "Failed to load LLM options",
     "save": "Failed to save slot. Please try again.",
     "nameRequired": "Name is required",
     "typeRequired": "Prompt slot type is required",
     "promptRequired": "Prompt is required",
+    "llmRequired": "LLM is required",
     "invalidImage": "Please upload an image file",
     "imageTooLarge": "Image size must be less than 5MB",
     "uploadImage": "Failed to upload image. Please try again."

--- a/frontend/src/pages/admin/NewOrEditPromptSlotVariant.tsx
+++ b/frontend/src/pages/admin/NewOrEditPromptSlotVariant.tsx
@@ -5,8 +5,8 @@ import { Label } from '@/components/ui/Label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
 import type { CreatePromptSlotVariantRequest, UpdatePromptSlotVariantRequest } from '@/lib/api';
-import { imagesApi, promptSlotTypesApi, promptSlotVariantsApi } from '@/lib/api';
-import type { PromptSlotType } from '@/types/promptSlotVariant';
+import { imagesApi, promptLlmsApi, promptSlotTypesApi, promptSlotVariantsApi } from '@/lib/api';
+import type { PromptSlotType, ProviderLLM } from '@/types/promptSlotVariant';
 import { Trash2, Upload } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -24,11 +24,14 @@ export default function NewOrEditPromptSlotVariant() {
     prompt: '',
     description: '',
     exampleImageFilename: undefined,
+    llm: '',
   });
   const [promptSlotTypes, setPromptSlotTypes] = useState<PromptSlotType[]>([]);
+  const [llmOptions, setLlmOptions] = useState<ProviderLLM[]>([]);
   const [loading, setLoading] = useState(false);
   const [initialLoading, setInitialLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [llmError, setLlmError] = useState<string | null>(null);
   const [uploadingImage, setUploadingImage] = useState(false);
   const [currentImageUrl, setCurrentImageUrl] = useState<string | null>(null);
   const [imageFile, setImageFile] = useState<File | null>(null);
@@ -44,11 +47,21 @@ export default function NewOrEditPromptSlotVariant() {
     }
   }, [t]);
 
+  const fetchLlmOptions = useCallback(async () => {
+    try {
+      const response = await promptLlmsApi.getAll();
+      setLlmOptions(response.llms);
+      setLlmError(null);
+    } catch (error) {
+      console.error('Error fetching llm options:', error);
+      setLlmError(t('promptSlotVariant.errors.loadLLMs'));
+    }
+  }, [t]);
+
   const fetchSlot = useCallback(async () => {
     if (!id) return;
 
     try {
-      setInitialLoading(true);
       const slot = await promptSlotVariantsApi.getById(parseInt(id));
       setFormData({
         name: slot.name,
@@ -56,26 +69,58 @@ export default function NewOrEditPromptSlotVariant() {
         prompt: slot.prompt,
         description: slot.description || '',
         exampleImageFilename: slot.exampleImageUrl ? slot.exampleImageUrl.split('/').pop() : undefined,
+        llm: slot.llm || '',
       });
+      if (slot.llm) {
+        setLlmOptions((current) => {
+          if (current.some((option) => option.llm === slot.llm)) {
+            return current;
+          }
+          return [
+            ...current,
+            {
+              llm: slot.llm,
+              provider: 'Unknown',
+              friendlyName: slot.llm,
+            },
+          ];
+        });
+      }
       if (slot.exampleImageUrl) {
         setCurrentImageUrl(slot.exampleImageUrl);
       }
     } catch (error) {
       console.error('Error fetching slot:', error);
       setError(t('promptSlotVariant.errors.load'));
-    } finally {
-      setInitialLoading(false);
     }
   }, [id, t]);
 
   useEffect(() => {
-    fetchPromptSlotTypes();
-    if (isEditing) {
-      fetchSlot();
-    } else {
-      setInitialLoading(false);
-    }
-  }, [fetchPromptSlotTypes, fetchSlot, isEditing]);
+    let isActive = true;
+    const load = async () => {
+      try {
+        setInitialLoading(true);
+        await Promise.all([fetchPromptSlotTypes(), fetchLlmOptions()]);
+        if (isEditing) {
+          await fetchSlot();
+        }
+      } finally {
+        if (isActive) {
+          setInitialLoading(false);
+        }
+      }
+    };
+
+    load().catch(() => {
+      if (isActive) {
+        setInitialLoading(false);
+      }
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [fetchPromptSlotTypes, fetchLlmOptions, fetchSlot, isEditing]);
 
   // Cleanup blob URLs
   useEffect(() => {
@@ -101,6 +146,11 @@ export default function NewOrEditPromptSlotVariant() {
 
     if (!formData.prompt.trim()) {
       setError(t('promptSlotVariant.errors.promptRequired'));
+      return;
+    }
+
+    if (!formData.llm.trim()) {
+      setError(t('promptSlotVariant.errors.llmRequired'));
       return;
     }
 
@@ -131,6 +181,7 @@ export default function NewOrEditPromptSlotVariant() {
           promptSlotTypeId: formData.promptSlotTypeId,
           prompt: formData.prompt,
           description: formData.description,
+          llm: formData.llm,
           // Send null to explicitly remove image, undefined to not change it
           exampleImageFilename: finalImageFilename === 'pending' ? undefined : (finalImageFilename ?? null),
         };
@@ -141,6 +192,7 @@ export default function NewOrEditPromptSlotVariant() {
           promptSlotTypeId: formData.promptSlotTypeId,
           prompt: formData.prompt,
           description: formData.description,
+          llm: formData.llm,
           // Send null to explicitly have no image, undefined to not set it
           exampleImageFilename: finalImageFilename === 'pending' ? undefined : (finalImageFilename ?? null),
         };
@@ -238,23 +290,45 @@ export default function NewOrEditPromptSlotVariant() {
               />
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="promptSlotType">{t('promptSlotVariant.form.type')}</Label>
-              <Select
-                value={formData.promptSlotTypeId.toString()}
-                onValueChange={(value) => setFormData({ ...formData, promptSlotTypeId: parseInt(value) })}
-              >
-                <SelectTrigger id="promptSlotType">
-                  <SelectValue placeholder={t('promptSlotVariant.form.typePlaceholder')} />
-                </SelectTrigger>
-                <SelectContent>
-                  {promptSlotTypes.map((type) => (
-                    <SelectItem key={type.id} value={type.id.toString()}>
-                      {type.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="promptSlotType">{t('promptSlotVariant.form.type')}</Label>
+                <Select
+                  value={formData.promptSlotTypeId.toString()}
+                  onValueChange={(value) => setFormData({ ...formData, promptSlotTypeId: parseInt(value) })}
+                >
+                  <SelectTrigger id="promptSlotType">
+                    <SelectValue placeholder={t('promptSlotVariant.form.typePlaceholder')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {promptSlotTypes.map((type) => (
+                      <SelectItem key={type.id} value={type.id.toString()}>
+                        {type.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="llm">{t('promptSlotVariant.form.llm')}</Label>
+                <Select value={formData.llm} onValueChange={(value) => setFormData({ ...formData, llm: value })} disabled={llmOptions.length === 0}>
+                  <SelectTrigger id="llm">
+                    <SelectValue placeholder={t('promptSlotVariant.form.llmPlaceholder')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {llmOptions.map((option) => (
+                      <SelectItem key={option.llm} value={option.llm}>
+                        {option.friendlyName}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {llmError ? (
+                  <p className="text-sm text-red-600">{llmError}</p>
+                ) : llmOptions.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">{t('promptSlotVariant.form.llmEmpty')}</p>
+                ) : null}
+              </div>
             </div>
 
             <div className="space-y-2">

--- a/frontend/src/types/promptSlotVariant.ts
+++ b/frontend/src/types/promptSlotVariant.ts
@@ -14,6 +14,13 @@ export interface PromptSlotVariant {
   prompt: string;
   description?: string;
   exampleImageUrl?: string;
+  llm: string;
   createdAt?: string;
   updatedAt?: string;
+}
+
+export interface ProviderLLM {
+  provider: string;
+  llm: string;
+  friendlyName: string;
 }


### PR DESCRIPTION
## Summary
- add a static provider/LLM catalog in the ai module and expose it through a dedicated admin endpoint
- inject the allowed LLM identifiers into the prompt service so validation and tests use the shared list
- update the admin slot variant form and client types to consume provider metadata and surface friendly names
- add an admin prompt form LLM selector backed by provider metadata and filter slot variants to matching LLMs

## Testing
- go test ./...
- npm run lint
- npm run type-check
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cb43cc9ed08321bffc46be0563a932